### PR TITLE
[WiP] Add ConvTranspose Layers

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
@@ -112,7 +112,7 @@ public class Conv1D(
         return tf.squeeze(result, squeezeAxis)
     }
 
-    protected override fun defineOutputShape(inputShape: Shape): Shape {
+    override fun defineOutputShape(inputShape: Shape): Shape {
         val batchSize = inputShape.size(0)
         val colsCount = inputShape.size(1)
 
@@ -128,8 +128,19 @@ public class Conv1D(
     }
 
     override fun toString(): String =
-        "Conv1D(filters=$filters, kernelSize=$kernelSize, strides=${strides.contentToString()}, " +
-                "dilation=${dilations.contentToString()}, activation=$activation, kernelInitializer=$kernelInitializer, " +
-                "biasInitializer=$biasInitializer, kernelShape=$kernelShape, biasShape=$biasShape, padding=$padding, " +
-                "biasRegularizer=$biasRegularizer, kernelRegularizer=$kernelRegularizer, activityRegularizer=$activityRegularizer)"
+        "Conv1D(" +
+                "filters=$filters, " +
+                "kernelSize=$kernelSize, " +
+                "strides=${strides.contentToString()}, " +
+                "dilation=${dilations.contentToString()}, " +
+                "activation=$activation, " +
+                "kernelInitializer=$kernelInitializer, " +
+                "biasInitializer=$biasInitializer, " +
+                "kernelShape=$kernelShape, " +
+                "biasShape=$biasShape, " +
+                "padding=$padding, " +
+                "biasRegularizer=$biasRegularizer, " +
+                "kernelRegularizer=$kernelRegularizer, " +
+                "activityRegularizer=$activityRegularizer" +
+                ")"
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
@@ -99,7 +99,7 @@ public class Conv2D(
         return tf.nn.conv2d(input, kernel, stridesInternal.toMutableList(), paddingInternal.paddingName, options)
     }
 
-    protected override fun defineOutputShape(inputShape: Shape): Shape {
+    override fun defineOutputShape(inputShape: Shape): Shape {
         val batchSize = inputShape.size(0)
         val rowsCount = inputShape.size(1)
         val colsCount = inputShape.size(2)
@@ -123,10 +123,21 @@ public class Conv2D(
     }
 
     override fun toString(): String =
-        "Conv2D(filters=$filters, kernelSize=${kernelSize.contentToString()}, strides=${strides.contentToString()}, " +
-                "dilations=${dilations.contentToString()}, activation=$activation, kernelInitializer=$kernelInitializer, " +
-                "biasInitializer=$biasInitializer, kernelShape=$kernelShape, biasShape=$biasShape, padding=$padding, " +
-                "biasRegularizer=$biasRegularizer, kernelRegularizer=$kernelRegularizer, activityRegularizer=$activityRegularizer)"
+        "Conv2D(" +
+                "filters=$filters, " +
+                "kernelSize=${kernelSize.contentToString()}, " +
+                "strides=${strides.contentToString()}, " +
+                "dilations=${dilations.contentToString()}, " +
+                "activation=$activation, " +
+                "kernelInitializer=$kernelInitializer, " +
+                "biasInitializer=$biasInitializer, " +
+                "kernelShape=$kernelShape, " +
+                "biasShape=$biasShape, " +
+                "padding=$padding, " +
+                "biasRegularizer=$biasRegularizer, " +
+                "kernelRegularizer=$kernelRegularizer, " +
+                "activityRegularizer=$activityRegularizer" +
+                ")"
 
     override fun kernelVarName(name: String): String = convKernelVarName(name, dim = 2)
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2DTranspose.kt
@@ -11,39 +11,39 @@ import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
 import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.*
-import org.jetbrains.kotlinx.dl.api.core.util.convBiasVarName
-import org.jetbrains.kotlinx.dl.api.core.util.convKernelVarName
+import org.jetbrains.kotlinx.dl.api.core.shape.convTransposeInputSizes
+import org.jetbrains.kotlinx.dl.api.core.shape.convTransposeOutputLength
+import org.jetbrains.kotlinx.dl.api.core.util.convTransposeBiasVarName
+import org.jetbrains.kotlinx.dl.api.core.util.convTransposeKernelVarName
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
-import org.tensorflow.op.nn.Conv3d.dilations
+import org.tensorflow.op.nn.Conv2dBackpropInput
 
-private const val KERNEL_VARIABLE_NAME = "conv3d_kernel"
+private const val KERNEL_VARIABLE_NAME = "conv2d_transpose_kernel"
 
-private const val BIAS_VARIABLE_NAME = "conv3d_bias"
+private const val BIAS_VARIABLE_NAME = "conv2d_transpose_bias"
 
 /**
- * 3D convolution layer (e.g. spatial convolution over video frames or 3D images).
+ * 2D convolution layer (e.g. spatial convolution over images).
  *
  * This layer creates a convolution kernel that is convolved (actually cross-correlated)
  * with the layer input to produce a tensor of outputs.
  * Finally, the `activation` is applied to the outputs as well.
  *
- * It expects input data of size `(N, D, H, W, C)` where
+ * It expects input data of size `(N, H, W, C)` where
  * ```
  * N - batch size
- * D - depth
  * H - height
  * W - width
  * C - number of channels
  * ```
  *
  * @property [filters] The dimensionality of the output space (i.e. the number of filters in the convolution).
- * @property [kernelSize] Three long numbers, specifying the height and width of the 3D convolution cube.
- * @property [strides] Five numbers, specifying the strides of the pooling operation for each dimension of input tensor.
+ * @property [kernelSize] Two long numbers, specifying the height and width of the 2D convolution window.
+ * @property [strides] Four numbers, specifying the strides of the pooling operation for each dimension of input tensor.
  * NOTE: Specifying any stride value != 1 is incompatible with specifying any `dilations` value != 1.
- * @property [dilations] Five numbers, specifying the dilation rate to use for dilated convolution for each dimension of input tensor.
+ * @property [dilations] Four numbers, specifying the dilation rate to use for dilated convolution for each dimension of input tensor.
  * @property [activation] Activation function.
  * @property [kernelInitializer] An initializer for the convolution kernel
  * @property [biasInitializer] An initializer for the bias vector.
@@ -51,17 +51,17 @@ private const val BIAS_VARIABLE_NAME = "conv3d_bias"
  * @property [biasRegularizer] Regularizer function applied to the `bias` vector.
  * @property [activityRegularizer] Regularizer function applied to the output of the layer (its "activation").
  * @property [padding] The padding method, either 'valid' or 'same' or 'full'.
+ * @property [outputPadding] Two long numbers specifying the amount of padding along the height and width of
+ * the output tensor. Defaults to null meaning the output shape is inferred.
  * @property [name] Custom layer name.
  * @property [useBias] If true the layer uses a bias vector.
- * @constructor Creates [Conv3D] object.
- *
- * @since 0.3
+ * @constructor Creates [Conv2D] object.
  */
-public class Conv3D(
+public class Conv2DTranspose(
     public val filters: Long = 32,
-    public val kernelSize: LongArray = longArrayOf(3, 3, 3),
-    public val strides: LongArray = longArrayOf(1, 1, 1, 1, 1),
-    public val dilations: LongArray = longArrayOf(1, 1, 1, 1, 1),
+    public val kernelSize: LongArray = longArrayOf(3, 3),
+    public val strides: LongArray = longArrayOf(1, 1, 1, 1),
+    public val dilations: LongArray = longArrayOf(1, 1, 1, 1),
     public val activation: Activations = Activations.Relu,
     public val kernelInitializer: Initializer = HeNormal(),
     public val biasInitializer: Initializer = HeUniform(),
@@ -69,6 +69,7 @@ public class Conv3D(
     public val biasRegularizer: Regularizer? = null,
     public val activityRegularizer: Regularizer? = null,
     public val padding: ConvPadding = ConvPadding.SAME,
+    public val outputPadding: LongArray? = null,
     public val useBias: Boolean = true,
     name: String = ""
 ) : AbstractConv(
@@ -89,57 +90,48 @@ public class Conv3D(
     name = name
 ) {
     init {
-        requireArraySize(kernelSize, 3, "kernelSize")
-        requireArraySize(strides, 5, "strides")
-        requireArraySize(dilations, 5, "dilations")
-        isTrainable = false
+        requireArraySize(kernelSize, 2, "kernelSize")
+        requireArraySize(strides, 4, "strides")
+        requireArraySize(dilations, 4, "dilations")
+        if (outputPadding != null) requireArraySize(outputPadding, 2, "outputPadding")
     }
-
-    override fun kernelVarName(name: String): String = convKernelVarName(name, dim = 3)
-
-    override fun biasVarName(name: String): String = convBiasVarName(name, dim = 3)
 
     override fun convImplementation(
         tf: Ops,
         input: Operand<Float>
     ): Operand<Float> {
-        val options = dilations(dilationsInternal.toList()).dataFormat("NDHWC")
-        return tf.nn.conv3d(input, kernel, stridesInternal.toMutableList(), paddingInternal.paddingName, options)
+        val inputSizes = convTransposeInputSizes(tf, outputShape)
+        val options = Conv2dBackpropInput.dilations(dilationsInternal.toList()).dataFormat("NHWC")
+        return tf.nn.conv2dBackpropInput(inputSizes, kernel, input, stridesInternal.toMutableList(), padding.paddingName, options)
     }
 
     override fun defineOutputShape(inputShape: Shape): Shape {
         val batchSize = inputShape.size(0)
-        val depthsCount = inputShape.size(1)
-        val rowsCount = inputShape.size(2)
-        val colsCount = inputShape.size(3)
+        val rowsCount = inputShape.size(1)
+        val colsCount = inputShape.size(2)
 
-        val depths = convOutputLength(
-            depthsCount,
+        val rows = convTransposeOutputLength(
+            rowsCount,
             kernelSizeInternal[0].toInt(),
             paddingInternal,
+            outputPadding?.get(0)?.toInt(),
             stridesInternal[1].toInt(),
             dilationsInternal[1].toInt()
         )
-        val rows = convOutputLength(
-            rowsCount,
+        val cols = convTransposeOutputLength(
+            colsCount,
             kernelSizeInternal[1].toInt(),
             paddingInternal,
+            outputPadding?.get(1)?.toInt(),
             stridesInternal[2].toInt(),
             dilationsInternal[2].toInt()
         )
-        val cols = convOutputLength(
-            colsCount,
-            kernelSizeInternal[2].toInt(),
-            paddingInternal,
-            stridesInternal[3].toInt(),
-            dilationsInternal[3].toInt()
-        )
 
-        return Shape.make(batchSize, depths, rows, cols, filtersInternal)
+        return Shape.make(batchSize, rows, cols, filtersInternal)
     }
 
     override fun toString(): String =
-        "Conv3D(" +
+        "Conv2DTranspose(" +
                 "filters=$filters, " +
                 "kernelSize=${kernelSize.contentToString()}, " +
                 "strides=${strides.contentToString()}, " +
@@ -150,8 +142,13 @@ public class Conv3D(
                 "kernelShape=$kernelShape, " +
                 "biasShape=$biasShape, " +
                 "padding=$padding, " +
+                "outputPadding=${outputPadding?.contentToString()} " +
                 "biasRegularizer=$biasRegularizer, " +
                 "kernelRegularizer=$kernelRegularizer, " +
                 "activityRegularizer=$activityRegularizer" +
                 ")"
+
+    override fun kernelVarName(name: String): String = convTransposeKernelVarName(name, dim = 2)
+
+    override fun biasVarName(name: String): String = convTransposeBiasVarName(name, dim = 2)
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3DTranspose.kt
@@ -12,16 +12,16 @@ import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
 import org.jetbrains.kotlinx.dl.api.core.shape.*
-import org.jetbrains.kotlinx.dl.api.core.util.convBiasVarName
-import org.jetbrains.kotlinx.dl.api.core.util.convKernelVarName
+import org.jetbrains.kotlinx.dl.api.core.util.convTransposeBiasVarName
+import org.jetbrains.kotlinx.dl.api.core.util.convTransposeKernelVarName
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
-import org.tensorflow.op.nn.Conv3d.dilations
+import org.tensorflow.op.nn.Conv3dBackpropInput
 
-private const val KERNEL_VARIABLE_NAME = "conv3d_kernel"
+private const val KERNEL_VARIABLE_NAME = "conv3d_transpose_kernel"
 
-private const val BIAS_VARIABLE_NAME = "conv3d_bias"
+private const val BIAS_VARIABLE_NAME = "conv3d_transpose_bias"
 
 /**
  * 3D convolution layer (e.g. spatial convolution over video frames or 3D images).
@@ -51,13 +51,15 @@ private const val BIAS_VARIABLE_NAME = "conv3d_bias"
  * @property [biasRegularizer] Regularizer function applied to the `bias` vector.
  * @property [activityRegularizer] Regularizer function applied to the output of the layer (its "activation").
  * @property [padding] The padding method, either 'valid' or 'same' or 'full'.
+ * @property [outputPadding] Three long numbers specifying the amount of padding along the height, width and depth of
+ * the output tensor. Defaults to null meaning the output shape is inferred.
  * @property [name] Custom layer name.
  * @property [useBias] If true the layer uses a bias vector.
  * @constructor Creates [Conv3D] object.
  *
  * @since 0.3
  */
-public class Conv3D(
+public class Conv3DTranspose(
     public val filters: Long = 32,
     public val kernelSize: LongArray = longArrayOf(3, 3, 3),
     public val strides: LongArray = longArrayOf(1, 1, 1, 1, 1),
@@ -69,6 +71,7 @@ public class Conv3D(
     public val biasRegularizer: Regularizer? = null,
     public val activityRegularizer: Regularizer? = null,
     public val padding: ConvPadding = ConvPadding.SAME,
+    public val outputPadding: LongArray? = null,
     public val useBias: Boolean = true,
     name: String = ""
 ) : AbstractConv(
@@ -92,19 +95,21 @@ public class Conv3D(
         requireArraySize(kernelSize, 3, "kernelSize")
         requireArraySize(strides, 5, "strides")
         requireArraySize(dilations, 5, "dilations")
+        if (outputPadding != null) requireArraySize(outputPadding, 3, "outputPadding")
         isTrainable = false
     }
 
-    override fun kernelVarName(name: String): String = convKernelVarName(name, dim = 3)
+    override fun kernelVarName(name: String): String = convTransposeKernelVarName(name, dim = 3)
 
-    override fun biasVarName(name: String): String = convBiasVarName(name, dim = 3)
+    override fun biasVarName(name: String): String = convTransposeBiasVarName(name, dim = 3)
 
     override fun convImplementation(
         tf: Ops,
         input: Operand<Float>
     ): Operand<Float> {
-        val options = dilations(dilationsInternal.toList()).dataFormat("NDHWC")
-        return tf.nn.conv3d(input, kernel, stridesInternal.toMutableList(), paddingInternal.paddingName, options)
+        val inputSizes = convTransposeInputSizes(tf, outputShape)
+        val options = Conv3dBackpropInput.dilations(dilationsInternal.toList()).dataFormat("NDHWC")
+        return tf.nn.conv3dBackpropInput(inputSizes, kernel, input, stridesInternal.toMutableList(), paddingInternal.paddingName, options)
     }
 
     override fun defineOutputShape(inputShape: Shape): Shape {
@@ -113,24 +118,27 @@ public class Conv3D(
         val rowsCount = inputShape.size(2)
         val colsCount = inputShape.size(3)
 
-        val depths = convOutputLength(
+        val depths = convTransposeOutputLength(
             depthsCount,
             kernelSizeInternal[0].toInt(),
             paddingInternal,
+            outputPadding?.get(0)?.toInt(),
             stridesInternal[1].toInt(),
             dilationsInternal[1].toInt()
         )
-        val rows = convOutputLength(
+        val rows = convTransposeOutputLength(
             rowsCount,
             kernelSizeInternal[1].toInt(),
             paddingInternal,
+            outputPadding?.get(1)?.toInt(),
             stridesInternal[2].toInt(),
             dilationsInternal[2].toInt()
         )
-        val cols = convOutputLength(
+        val cols = convTransposeOutputLength(
             colsCount,
             kernelSizeInternal[2].toInt(),
             paddingInternal,
+            outputPadding?.get(2)?.toInt(),
             stridesInternal[3].toInt(),
             dilationsInternal[3].toInt()
         )
@@ -139,7 +147,7 @@ public class Conv3D(
     }
 
     override fun toString(): String =
-        "Conv3D(" +
+        "Conv3DTranspose(" +
                 "filters=$filters, " +
                 "kernelSize=${kernelSize.contentToString()}, " +
                 "strides=${strides.contentToString()}, " +
@@ -150,6 +158,7 @@ public class Conv3D(
                 "kernelShape=$kernelShape, " +
                 "biasShape=$biasShape, " +
                 "padding=$padding, " +
+                "outputPadding=${outputPadding?.contentToString()} " +
                 "biasRegularizer=$biasRegularizer, " +
                 "kernelRegularizer=$kernelRegularizer, " +
                 "activityRegularizer=$activityRegularizer" +

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/util/nameConventions.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/util/nameConventions.kt
@@ -25,6 +25,12 @@ internal fun convBiasVarName(name: String, dim: Int) = name + "_" + "conv${dim}d
 /** Default Conv kernel variable name in TensorFlow graph, based on variable's name. */
 internal fun convKernelVarName(name: String, dim: Int) = name + "_" + "conv${dim}d_kernel"
 
+/** Default ConvTranspose bias variable name in TensorFlow graph, based on variable's name. */
+internal fun convTransposeBiasVarName(name: String, dim: Int) = name + "_" + "conv${dim}d_transpose_bias"
+
+/** Default ConvTranspose kernel variable name in TensorFlow graph, based on variable's name. */
+internal fun convTransposeKernelVarName(name: String, dim: Int) = name + "_" + "conv${dim}d_transpose_kernel"
+
 /** Default DepthwiseConv2d bias variable name in TensorFlow graph, based on variable's name. */
 internal fun depthwiseConv2dBiasVarName(name: String) = name + "_" + "depthwise_conv2d_bias"
 


### PR DESCRIPTION
Closes #124.

Work status:
- [x] Implementation of layer class named as Conv2DTranspose (you can take inspiration from the implementation of Conv2D as reference)
- [x]  Implementation of layer class named as Conv3DTranspose (you can take inspiration from the implementation of Conv3D as reference)
- [ ]  Implementation of layer class named as Conv1DTranspose
- [ ]  Common hierarchy of all ConvTranspose layers with abstract class with the common functionality (reused AbstractConv from standard conv operation)
- [ ]  Documentation of layer and all non-private methods
- [ ]  JUnit tests in api module
- [ ]  Support for export of layer to JSON (see ModelSaver.kt)
- [ ]  Support for import of layer from JSON (see ModelLoader.kt)