### PR TITLE
Fix cudnn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ You will also need to add the following dependencies in your project if you wish
 
 On Windows, the following distributions are required:
 - CUDA cuda_10.0.130_411.31_win10
-- [cudnn-10.0](https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.3.30/Production/10.0_20190822/cudnn-10.0-windows10-x64-v7.6.3.30.zip)
+- [cudnn-7.6.3](https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.3.30/Production/10.0_20190822/cudnn-10.0-windows10-x64-v7.6.3.30.zip)
 - [C++ redistributable parts](https://www.microsoft.com/en-us/download/details.aspx?id=48145) 
 
 ## Logging


### PR DESCRIPTION
Hi, 

This PR is a small fix for the README.

I get confused when I install CUDA and cudnn for KotlinDL.

The latest version of cudnn is v8.1 but the doc says it requires cudnn-10.0, then I realise that it means cudnn 7.6.3 + cuda 10.0.


