### PR TITLE
Fix layers import and export

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/PReLU.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/PReLU.kt
@@ -41,7 +41,7 @@ public class PReLU(
      * TODO: support for constraint (alphaConstraint) should be added
      */
 
-    private lateinit var alpha: KVariable
+    internal lateinit var alpha: KVariable
     private fun alphaVariableName(): String =
         if (name.isNotEmpty()) "${name}_alpha" else "alpha"
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping2D.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -67,6 +67,6 @@ public class Cropping2D(
     }
 
     override fun toString(): String {
-        return "Cropping2D(name = $name, isTrainable=$isTrainable, cropping=${cropping.contentToString()}, hasActivation=$hasActivation)"
+        return "Cropping2D(name = $name, isTrainable=$isTrainable, cropping=${cropping.contentDeepToString()}, hasActivation = $hasActivation)"
     }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping3D.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -70,6 +70,6 @@ public class Cropping3D(
     }
 
     override fun toString(): String {
-        return "Cropping3D(name = $name, isTrainable=$isTrainable, cropping=${cropping.contentToString()}, hasActivation=$hasActivation)"
+        return "Cropping3D(name = $name, isTrainable=$isTrainable, cropping=${cropping.contentDeepToString()}, hasActivation=$hasActivation)"
     }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
@@ -411,7 +411,8 @@ private fun createConcatenateLayer(config: LayerConfig): Layer {
 
 private fun createDotLayer(config: LayerConfig): Layer {
     return Dot(
-        axis = config.axis!! as IntArray
+        axis = config.axis!! as IntArray,
+        normalize = config.normalize ?: false
     )
 }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
@@ -445,7 +445,7 @@ private fun createPReLULayer(config: LayerConfig): Layer {
     return PReLU(
         alphaInitializer = convertToInitializer(config.alpha_initializer!!),
         alphaRegularizer = convertToRegularizer(config.alpha_regularizer),
-        sharedAxes = config.shared_axes!!.toIntArray()
+        sharedAxes = config.shared_axes?.toIntArray()
     )
 }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -657,7 +657,8 @@ private fun createKerasDotLayer(layer: Dot): KerasLayer {
         dtype = DATATYPE_FLOAT32,
         axis = layer.axis,
         name = layer.name,
-        trainable = layer.isTrainable
+        trainable = layer.isTrainable,
+        normalize = layer.normalize
     )
     return KerasLayer(class_name = LAYER_DOT, config = configX)
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -571,8 +571,8 @@ private fun createKerasAvgPool1DLayer(layer: AvgPool1D): KerasLayer {
 }
 
 private fun createKerasMaxPool3DLayer(layer: MaxPool3D): KerasLayer {
-    val poolSize = mutableListOf(layer.poolSize[1], layer.poolSize[3])
-    val strides = mutableListOf(layer.strides[1], layer.strides[3])
+    val poolSize = mutableListOf(layer.poolSize[1], layer.poolSize[2], layer.poolSize[3])
+    val strides = mutableListOf(layer.strides[1], layer.strides[2], layer.strides[3])
     val configX = LayerConfig(
         dtype = DATATYPE_FLOAT32,
         name = layer.name,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -97,6 +97,7 @@ private fun convertToKerasLayer(layer: Layer, isKerasFullyCompatible: Boolean, i
         is UpSampling1D -> createKerasUpSampling1DLayer(layer)
         is UpSampling2D -> createKerasUpSampling2DLayer(layer)
         is UpSampling3D -> createKerasUpSampling3DLayer(layer)
+        is Reshape -> createKerasReshapeLayer(layer)
         // Merging layers
         is Add -> createKerasAddLayer(layer)
         is Maximum -> createKerasMaximumLayer(layer)
@@ -924,4 +925,13 @@ private fun createKerasUpSampling3DLayer(layer: UpSampling3D): KerasLayer {
         trainable = layer.isTrainable,
     )
     return KerasLayer(class_name = LAYER_UP_SAMPLING_3D, config = configX)
+}
+
+private fun createKerasReshapeLayer(layer: Reshape): KerasLayer {
+    val configX = LayerConfig(
+        target_shape = layer.targetShape,
+        name = layer.name,
+        trainable = layer.isTrainable,
+    )
+    return KerasLayer(class_name = LAYER_RESHAPE, config = configX)
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -432,6 +432,7 @@ private fun createKerasReLULayer(layer: ReLU): KerasLayer {
         max_value = layer.maxValue?.toDouble(),
         negative_slope = layer.negativeSlope.toDouble(),
         threshold = layer.threshold.toDouble(),
+        name = layer.name,
         trainable = layer.isTrainable
     )
     return KerasLayer(class_name = LAYER_RELU, config = configX)
@@ -441,6 +442,7 @@ private fun createKerasELULayer(layer: ELU): KerasLayer {
     val configX = LayerConfig(
         dtype = DATATYPE_FLOAT32,
         alpha = layer.alpha.toDouble(),
+        name = layer.name,
         trainable = layer.isTrainable
     )
     return KerasLayer(class_name = LAYER_ELU, config = configX)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlinx.dl.api.inference.keras
 
 import org.jetbrains.kotlinx.dl.api.core.layer.KVariable
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
-import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv2D
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.AbstractConv
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvTranspose
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.DepthwiseConv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.SeparableConv2D
@@ -31,10 +31,10 @@ internal object WeightMappings {
     internal fun getLayerVariables(layer: Layer): Map<String, KVariable>? {
         return when (layer) {
             is Dense -> getDenseVariables(layer)
-            is Conv2D -> getConv2DVariables(layer)
             is ConvTranspose -> getConvTransposeVariables(layer)
             is DepthwiseConv2D -> getDepthwiseConv2DVariables(layer)
             is SeparableConv2D -> getSeparableConv2DVariables(layer)
+            is AbstractConv -> getConvVariables(layer)
             is BatchNorm -> getBatchNormVariables(layer)
             else -> null
         }
@@ -47,20 +47,20 @@ internal object WeightMappings {
     internal fun getLayerVariablePathTemplates(layer: Layer, layerPaths: LayerPaths?): Map<KVariable, String>? {
         return when (layer) {
             is Dense -> getDenseVariablesPathTemplates(layer, layerPaths)
-            is Conv2D -> getConv2DVariablePathTemplates(layer, layerPaths)
             is ConvTranspose -> getConvTransposeVariablePathTemplates(layer, layerPaths)
             is DepthwiseConv2D -> getDepthwiseConv2DVariablePathTemplates(layer, layerPaths)
             is SeparableConv2D -> getSeparableConv2DVariablePathTemplates(layer, layerPaths)
+            is AbstractConv -> getConvVariablePathTemplates(layer, layerPaths)
             is BatchNorm -> getBatchNormVariablePathTemplates(layer, layerPaths)
             else -> null
         }
     }
 
-    private fun getConv2DVariables(layer: Conv2D): Map<String, KVariable> {
+    private fun getConvVariables(layer: AbstractConv): Map<String, KVariable> {
         return mapOfNotNull("kernel:0" to layer.kernel, "bias:0" to layer.bias)
     }
 
-    private fun getConv2DVariablePathTemplates(layer: Conv2D, layerPaths: LayerPaths?): Map<KVariable, String> {
+    private fun getConvVariablePathTemplates(layer: AbstractConv, layerPaths: LayerPaths?): Map<KVariable, String> {
         val layerConvOrDensePaths = layerPaths as? LayerConvOrDensePaths
             ?: LayerConvOrDensePaths(layer.name, KERNEL_DATA_PATH_TEMPLATE, BIAS_DATA_PATH_TEMPLATE)
         return mapOfNotNull(

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlinx.dl.api.inference.keras
 
 import org.jetbrains.kotlinx.dl.api.core.layer.KVariable
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
+import org.jetbrains.kotlinx.dl.api.core.layer.activation.PReLU
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.AbstractConv
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvTranspose
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.DepthwiseConv2D
@@ -26,6 +27,7 @@ internal object WeightMappings {
     private const val DEPTHWISE_KERNEL_DATA_PATH_TEMPLATE = "/%s/%s/depthwise_kernel:0"
     private const val POINTWISE_KERNEL_DATA_PATH_TEMPLATE = "/%s/%s/pointwise_kernel:0"
     private const val DEPTHWISE_BIAS_DATA_PATH_TEMPLATE = "/%s/%s/depthwise_bias:0"
+    private const val PRELU_ALPHA_DATA_PATH_TEMPLATE = "/%s/%s/alpha:0"
 
     // TODO: add loading for all layers with weights from Keras like Conv1D and Conv3D
     internal fun getLayerVariables(layer: Layer): Map<String, KVariable>? {
@@ -36,6 +38,7 @@ internal object WeightMappings {
             is SeparableConv2D -> getSeparableConv2DVariables(layer)
             is AbstractConv -> getConvVariables(layer)
             is BatchNorm -> getBatchNormVariables(layer)
+            is PReLU -> getPReLUVariables(layer)
             else -> null
         }
     }
@@ -52,6 +55,7 @@ internal object WeightMappings {
             is SeparableConv2D -> getSeparableConv2DVariablePathTemplates(layer, layerPaths)
             is AbstractConv -> getConvVariablePathTemplates(layer, layerPaths)
             is BatchNorm -> getBatchNormVariablePathTemplates(layer, layerPaths)
+            is PReLU -> getPReLUVariablePathTemplates(layer, layerPaths)
             else -> null
         }
     }
@@ -167,6 +171,16 @@ internal object WeightMappings {
             layer.beta to layerBatchNormPaths.betaPath
         )
     }
+
+    private fun getPReLUVariables(layer: PReLU): Map<String, KVariable> {
+        return mapOfNotNull("alpha:0" to layer.alpha)
+    }
+
+    private fun getPReLUVariablePathTemplates(layer: PReLU, layerPaths: LayerPaths?): Map<KVariable, String> {
+        val layerPReLUPaths = layerPaths as? LayerPReLUPaths
+            ?: LayerPReLUPaths(layer.name, PRELU_ALPHA_DATA_PATH_TEMPLATE)
+        return mapOfNotNull(layer.alpha to layerPReLUPaths.alphaPath)
+    }
 }
 
 /**
@@ -226,3 +240,12 @@ public class LayerBatchNormPaths(
     /** */
     public val movingVariancePath: String
 ) : LayerPaths(layerName)
+
+/**
+ * Contains [layerName], [alphaPath] for [PReLU] layer, found in hdf5 file via
+ * ```
+ * recursivePrintGroupInHDF5File()
+ * ```
+ * function call.
+ */
+public class LayerPReLUPaths(layerName: String, public val alphaPath: String) : LayerPaths(layerName)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/LayerConfig.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/LayerConfig.kt
@@ -157,5 +157,7 @@ internal data class LayerConfig(
     @Json(serializeNull = false)
     val use_bias: Boolean? = null,
     @Json(serializeNull = false)
-    val dims: IntArray? = null
+    val dims: IntArray? = null,
+    @Json(serializeNull = false)
+    val normalize: Boolean? = null
 )

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ActivationLayersImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ActivationLayersImportExportTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import org.jetbrains.kotlinx.dl.api.core.Sequential
+import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
+import org.jetbrains.kotlinx.dl.api.core.layer.activation.*
+import org.jetbrains.kotlinx.dl.api.core.layer.core.ActivationLayer
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.regularizer.L2
+import org.junit.jupiter.api.Test
+
+class ActivationLayersImportExportTest {
+    @Test
+    fun activationLayer() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100),
+                ActivationLayer(name = "test_activation_layer", activation = Activations.Exponential)
+            )
+        )
+    }
+
+    @Test
+    fun elu() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100),
+                ELU(name = "test_elu", alpha = 0.5f)
+            )
+        )
+    }
+
+    @Test
+    fun leakyRelu() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100),
+                LeakyReLU(name = "test_leaky_relu", alpha = 0.5f)
+            )
+        )
+    }
+
+    @Test
+    fun prelu() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100),
+                PReLU(
+                    name = "test_prelu",
+                    alphaInitializer = HeNormal(),
+                    alphaRegularizer = L2(),
+                    sharedAxes = intArrayOf(1)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun relu() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100),
+                ReLU(name = "test_relu", maxValue = 2.0f, threshold = 0.1f, negativeSlope = 2.0f)
+            )
+        )
+    }
+
+    @Test
+    fun softmax() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100),
+                Softmax(name = "test_softmax", axis = listOf(1))
+            )
+        )
+    }
+
+    @Test
+    fun thresholdedRelu() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100),
+                ThresholdedReLU(name = "test_thresholded_relu", theta = 2f)
+            )
+        )
+    }
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ConvolutionalLayersImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ConvolutionalLayersImportExportTest.kt
@@ -13,10 +13,10 @@ import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
 import org.jetbrains.kotlinx.dl.api.core.regularizer.L2
 import org.junit.jupiter.api.Test
 
-class ConvolutionalLayersPersistenceTest {
+class ConvolutionalLayersImportExportTest {
     @Test
     fun conv1D() {
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             Sequential.of(
                 Input(dims = longArrayOf(256, 1)),
                 Conv1D(
@@ -40,7 +40,7 @@ class ConvolutionalLayersPersistenceTest {
 
     @Test
     fun conv2D() {
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             Sequential.of(
                 Input(dims = longArrayOf(256, 256, 3)),
                 Conv2D(
@@ -64,7 +64,7 @@ class ConvolutionalLayersPersistenceTest {
 
     @Test
     fun conv3D() {
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             Sequential.of(
                 Input(dims = longArrayOf(10, 256, 256, 3)),
                 Conv3D(
@@ -88,7 +88,7 @@ class ConvolutionalLayersPersistenceTest {
 
     @Test
     fun conv1DTranspose() {
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             Sequential.of(
                 Input(dims = longArrayOf(3)),
                 Conv1DTranspose(
@@ -113,7 +113,7 @@ class ConvolutionalLayersPersistenceTest {
 
     @Test
     fun conv2DTranspose() {
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             Sequential.of(
                 Input(dims = longArrayOf(3, 3)),
                 Conv2DTranspose(
@@ -138,7 +138,7 @@ class ConvolutionalLayersPersistenceTest {
 
     @Test
     fun conv3DTranspose() {
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             Sequential.of(
                 Input(dims = longArrayOf(3, 3, 3)),
                 Conv3DTranspose(
@@ -161,8 +161,8 @@ class ConvolutionalLayersPersistenceTest {
     }
 
     @Test
-    fun separableConvTest() {
-        LayerPersistenceTest.run(
+    fun separableConv() {
+        LayerImportExportTest.run(
             Sequential.of(
                 Input(dims = longArrayOf(30, 30, 3)),
                 SeparableConv2D(
@@ -188,8 +188,8 @@ class ConvolutionalLayersPersistenceTest {
     }
 
     @Test
-    fun depthwiseConvTest() {
-        LayerPersistenceTest.run(
+    fun depthwiseConv() {
+        LayerImportExportTest.run(
             Sequential.of(
                 Input(dims = longArrayOf(30, 30, 3)),
                 DepthwiseConv2D(

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/CoreLayersImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/CoreLayersImportExportTest.kt
@@ -7,10 +7,16 @@ package org.jetbrains.kotlinx.dl.api.inference.keras
 
 import org.jetbrains.kotlinx.dl.api.core.Functional
 import org.jetbrains.kotlinx.dl.api.core.Sequential
+import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.regularizer.L2
+import org.jetbrains.kotlinx.dl.api.core.regularizer.L2L1
 import org.junit.jupiter.api.Test
 
-class InputLayerImportExportTest {
+class CoreLayersImportExportTest {
     @Test
     fun inputLayerSequential() {
         LayerImportExportTest.run(Sequential.of(Input(4)))
@@ -25,5 +31,25 @@ class InputLayerImportExportTest {
         LayerImportExportTest.run(Functional.of(Input(128, 128)))
         LayerImportExportTest.run(Functional.of(Input(128, 128, 3)))
         LayerImportExportTest.run(Functional.of(Input(10, 10, 10, 10)))
+    }
+
+    @Test
+    fun denseLayer() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(10),
+                Dense(
+                    name = "test_dense",
+                    outputSize = 10,
+                    activation = Activations.Tanh,
+                    kernelInitializer = HeNormal(),
+                    biasInitializer = HeUniform(),
+                    kernelRegularizer = L2(),
+                    biasRegularizer = L2(),
+                    activityRegularizer = L2L1(),
+                    useBias = true
+                )
+            )
+        )
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/DropoutBatchNormImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/DropoutBatchNormImportExportTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import org.jetbrains.kotlinx.dl.api.core.Sequential
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
+import org.jetbrains.kotlinx.dl.api.core.layer.regularization.Dropout
+import org.jetbrains.kotlinx.dl.api.core.regularizer.L2
+import org.junit.jupiter.api.Test
+
+class DropoutBatchNormImportExportTest {
+    @Test
+    fun dropout() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(10),
+                Dropout(name = "test_dropout", rate = 0.2f)
+            )
+        )
+    }
+
+    @Test
+    fun batchNorm() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(10),
+                BatchNorm(
+                    name = "test_batch_norm", axis = listOf(1),
+                    momentum = 0.9, center = false, epsilon = 0.002, scale = false,
+                    gammaInitializer = HeUniform(), betaInitializer = HeNormal(),
+                    betaRegularizer = L2(), gammaRegularizer = L2(),
+                    movingMeanInitializer = HeNormal(), movingVarianceInitializer = HeUniform()
+                )
+            )
+        )
+    }
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/InputLayerImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/InputLayerImportExportTest.kt
@@ -12,47 +12,47 @@ import org.jetbrains.kotlinx.dl.api.core.dsl.sequential
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
 import org.junit.jupiter.api.Test
 
-class InputLayerPersistenceTest {
+class InputLayerImportExportTest {
     @Test
     fun inputLayerSequential() {
-        LayerPersistenceTest.run(Sequential.of(Input(4)))
-        LayerPersistenceTest.run(Sequential.of(Input(128, 128)))
-        LayerPersistenceTest.run(Sequential.of(Input(128, 128, 3)))
-        LayerPersistenceTest.run(Sequential.of(Input(10, 10, 10, 10)))
+        LayerImportExportTest.run(Sequential.of(Input(4)))
+        LayerImportExportTest.run(Sequential.of(Input(128, 128)))
+        LayerImportExportTest.run(Sequential.of(Input(128, 128, 3)))
+        LayerImportExportTest.run(Sequential.of(Input(10, 10, 10, 10)))
     }
 
     @Test
     fun inputLayerFunctional() {
-        LayerPersistenceTest.run(Functional.of(Input(10)))
-        LayerPersistenceTest.run(Functional.of(Input(128, 128)))
-        LayerPersistenceTest.run(Functional.of(Input(128, 128, 3)))
-        LayerPersistenceTest.run(Functional.of(Input(10, 10, 10, 10)))
+        LayerImportExportTest.run(Functional.of(Input(10)))
+        LayerImportExportTest.run(Functional.of(Input(128, 128)))
+        LayerImportExportTest.run(Functional.of(Input(128, 128, 3)))
+        LayerImportExportTest.run(Functional.of(Input(10, 10, 10, 10)))
     }
 
     @Test
     fun dslBuilderSequential() {
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             sequential {
                 layers {
                     +Input(4)
                 }
             }
         )
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             sequential {
                 layers {
                     +Input(128, 128)
                 }
             }
         )
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             sequential {
                 layers {
                     +Input(128, 128, 3)
                 }
             }
         )
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             sequential {
                 layers {
                     +Input(10, 10, 10, 10)
@@ -63,28 +63,28 @@ class InputLayerPersistenceTest {
 
     @Test
     fun dslBuilderFunctional() {
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             functional {
                 layers {
                     +Input(4)
                 }
             }
         )
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             functional {
                 layers {
                     +Input(128, 128)
                 }
             }
         )
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             functional {
                 layers {
                     +Input(128, 128, 3)
                 }
             }
         )
-        LayerPersistenceTest.run(
+        LayerImportExportTest.run(
             functional {
                 layers {
                     +Input(10, 10, 10, 10)

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/InputLayerImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/InputLayerImportExportTest.kt
@@ -7,8 +7,6 @@ package org.jetbrains.kotlinx.dl.api.inference.keras
 
 import org.jetbrains.kotlinx.dl.api.core.Functional
 import org.jetbrains.kotlinx.dl.api.core.Sequential
-import org.jetbrains.kotlinx.dl.api.core.dsl.functional
-import org.jetbrains.kotlinx.dl.api.core.dsl.sequential
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
 import org.junit.jupiter.api.Test
 
@@ -27,69 +25,5 @@ class InputLayerImportExportTest {
         LayerImportExportTest.run(Functional.of(Input(128, 128)))
         LayerImportExportTest.run(Functional.of(Input(128, 128, 3)))
         LayerImportExportTest.run(Functional.of(Input(10, 10, 10, 10)))
-    }
-
-    @Test
-    fun dslBuilderSequential() {
-        LayerImportExportTest.run(
-            sequential {
-                layers {
-                    +Input(4)
-                }
-            }
-        )
-        LayerImportExportTest.run(
-            sequential {
-                layers {
-                    +Input(128, 128)
-                }
-            }
-        )
-        LayerImportExportTest.run(
-            sequential {
-                layers {
-                    +Input(128, 128, 3)
-                }
-            }
-        )
-        LayerImportExportTest.run(
-            sequential {
-                layers {
-                    +Input(10, 10, 10, 10)
-                }
-            }
-        )
-    }
-
-    @Test
-    fun dslBuilderFunctional() {
-        LayerImportExportTest.run(
-            functional {
-                layers {
-                    +Input(4)
-                }
-            }
-        )
-        LayerImportExportTest.run(
-            functional {
-                layers {
-                    +Input(128, 128)
-                }
-            }
-        )
-        LayerImportExportTest.run(
-            functional {
-                layers {
-                    +Input(128, 128, 3)
-                }
-            }
-        )
-        LayerImportExportTest.run(
-            functional {
-                layers {
-                    +Input(10, 10, 10, 10)
-                }
-            }
-        )
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/LayerImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/LayerImportExportTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -13,7 +13,7 @@ import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.junit.jupiter.api.Assertions
 
-object LayerPersistenceTest {
+object LayerImportExportTest {
     internal fun run(originalModel: Sequential) {
         val kerasModel = originalModel.serializeModel(false)
         val restoredModel = deserializeSequentialModel(kerasModel)

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/LayerImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/LayerImportExportTest.kt
@@ -30,7 +30,7 @@ object LayerImportExportTest {
         listOf(expectedModel, actualModel).forEach {
             it.compile(Adam(), Losses.MSE, Metrics.ACCURACY)
         }
-        Assertions.assertEquals(expectedModel.layers.joinToString("\n") { it.toString() },
-                                actualModel.layers.joinToString("\n") { it.toString() })
+        Assertions.assertEquals(expectedModel.layers.joinToString("\n"),
+                                actualModel.layers.joinToString("\n"))
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/MergeLayersImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/MergeLayersImportExportTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import org.jetbrains.kotlinx.dl.api.core.dsl.functional
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.layer.merge.*
+import org.junit.jupiter.api.Test
+
+class MergeLayersImportExportTest {
+    @Test
+    fun add() {
+        LayerImportExportTest.run(
+            functional {
+                layers {
+                    val input = +Input(10)
+                    val dense1 = +Dense(name = "Dense1", outputSize = 5)(input)
+                    val dense2 = +Dense(name = "Dense2", outputSize = 5)(input)
+                    +Add("test_add")(dense1, dense2)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun subtract() {
+        LayerImportExportTest.run(
+            functional {
+                layers {
+                    val input = +Input(10)
+                    val dense1 = +Dense(name = "Dense1", outputSize = 5)(input)
+                    val dense2 = +Dense(name = "Dense2", outputSize = 5)(input)
+                    +Subtract("test_subtract")(dense1, dense2)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun multiply() {
+        LayerImportExportTest.run(
+            functional {
+                layers {
+                    val input = +Input(10)
+                    val dense1 = +Dense(name = "Dense1", outputSize = 5)(input)
+                    val dense2 = +Dense(name = "Dense2", outputSize = 5)(input)
+                    +Multiply("test_multiply")(dense1, dense2)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun maximum() {
+        LayerImportExportTest.run(
+            functional {
+                layers {
+                    val input = +Input(10)
+                    val dense1 = +Dense(name = "Dense1", outputSize = 5)(input)
+                    val dense2 = +Dense(name = "Dense2", outputSize = 5)(input)
+                    +Maximum("test_maximum")(dense1, dense2)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun minimum() {
+        LayerImportExportTest.run(
+            functional {
+                layers {
+                    val input = +Input(10)
+                    val dense1 = +Dense(name = "Dense1", outputSize = 5)(input)
+                    val dense2 = +Dense(name = "Dense2", outputSize = 5)(input)
+                    +Minimum("test_minimum")(dense1, dense2)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun average() {
+        LayerImportExportTest.run(
+            functional {
+                layers {
+                    val input = +Input(10)
+                    val dense1 = +Dense(name = "Dense1", outputSize = 5)(input)
+                    val dense2 = +Dense(name = "Dense2", outputSize = 5)(input)
+                    +Average("test_average")(dense1, dense2)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun concatenate() {
+        LayerImportExportTest.run(
+            functional {
+                layers {
+                    val input = +Input(10)
+                    val dense1 = +Dense(name = "Dense1", outputSize = 5)(input).apply { isTrainable = false }
+                    val dense2 = +Dense(name = "Dense2", outputSize = 5)(input).apply { isTrainable = false }
+                    +Concatenate(name = "test_concatenate", axis = 1)(dense1, dense2)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun dot() {
+        LayerImportExportTest.run(
+            functional {
+                layers {
+                    val input = +Input(10)
+                    val dense1 = +Dense(name = "Dense1", outputSize = 5)(input)
+                    val dense2 = +Dense(name = "Dense2", outputSize = 5)(input)
+                    +Dot(name = "test_dot", axis = intArrayOf(1, 1), normalize = true)(dense1, dense2)
+                }
+            }
+        )
+    }
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/PoolingLayersImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/PoolingLayersImportExportTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import org.jetbrains.kotlinx.dl.api.core.Sequential
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.layer.pooling.*
+import org.junit.jupiter.api.Test
+
+class PoolingLayersImportExportTest {
+    @Test
+    fun avgPool1D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 3),
+                AvgPool1D(name = "test_avg_pool", poolSize = 4, strides = 4, padding = ConvPadding.SAME)
+            )
+        )
+    }
+
+    @Test
+    fun avgPool2D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 3),
+                AvgPool2D(name = "test_avg_pool", poolSize = intArrayOf(1, 5, 3, 1), strides = intArrayOf(1, 5, 3, 1), padding = ConvPadding.SAME)
+            )
+        )
+    }
+
+    @Test
+    fun avgPool3D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 100, 3),
+                AvgPool3D(name = "test_avg_pool", poolSize = intArrayOf(1, 7, 5, 3, 1), strides = intArrayOf(1, 7, 5, 3, 1), padding = ConvPadding.SAME)
+            )
+        )
+    }
+
+    @Test
+    fun maxPool1D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 3),
+                MaxPool1D(name = "test_max_pool", poolSize = 4, strides = 4, padding = ConvPadding.SAME)
+            )
+        )
+    }
+
+    @Test
+    fun maxPool2D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 3),
+                MaxPool2D(name = "test_max_pool", poolSize = intArrayOf(1, 5, 3, 1), strides = intArrayOf(1, 5, 3, 1), padding = ConvPadding.SAME)
+            )
+        )
+    }
+
+    @Test
+    fun maxPool3D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 100, 10),
+                MaxPool3D(name = "test_max_pool", poolSize = intArrayOf(1, 7, 5, 3, 1), strides = intArrayOf(1, 7, 5, 3, 1), padding = ConvPadding.SAME)
+            )
+        )
+    }
+
+    @Test
+    fun globalAvgPool1D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 3),
+                GlobalAvgPool1D(name = "test_global_avg_pool")
+            )
+        )
+    }
+
+    @Test
+    fun globalAvgPool2D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 3),
+                GlobalAvgPool2D(name = "test_global_avg_pool")
+            )
+        )
+    }
+
+    @Test
+    fun globalAvgPool3D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 100, 3),
+                GlobalAvgPool3D(name = "test_global_avg_pool")
+            )
+        )
+    }
+
+    @Test
+    fun globalMaxPool1D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 3),
+                GlobalMaxPool1D(name = "test_global_max_pool")
+            )
+        )
+    }
+
+    @Test
+    fun globalMaxPool2D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 3),
+                GlobalMaxPool2D(name = "test_global_max_pool")
+            )
+        )
+    }
+
+    @Test
+    fun globalMaxPool3D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 100, 5),
+                GlobalMaxPool3D(name = "test_global_max_pool")
+            )
+        )
+    }
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ReshapingLayersImportExportTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ReshapingLayersImportExportTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import org.jetbrains.kotlinx.dl.api.core.Sequential
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.layer.reshaping.*
+import org.junit.jupiter.api.Test
+
+class ReshapingLayersImportExportTest {
+    @Test
+    fun cropping1D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 2),
+                Cropping1D(name = "test_cropping", cropping = intArrayOf(1, 2))
+            )
+        )
+    }
+
+    @Test
+    fun cropping2D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 3),
+                Cropping2D(name = "test_cropping", cropping = arrayOf(intArrayOf(1, 2), intArrayOf(3, 4)))
+            )
+        )
+    }
+
+    @Test
+    fun cropping3D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 100, 2),
+                Cropping3D(
+                    name = "test_cropping",
+                    cropping = arrayOf(intArrayOf(1, 2), intArrayOf(3, 4), intArrayOf(5, 6))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun upSampling1D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 2),
+                UpSampling1D(name = "test_upsampling", size = 4)
+            )
+        )
+    }
+
+    @Test
+    fun upSampling2D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 3),
+                UpSampling2D(name = "test_upsampling", size = intArrayOf(1, 4))
+            )
+        )
+    }
+
+    @Test
+    fun upSampling3D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 100, 2),
+                UpSampling3D(name = "test_upsampling", size = intArrayOf(1, 4, 5))
+            )
+        )
+    }
+
+    @Test
+    fun zeroPadding1D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 2),
+                ZeroPadding1D(name = "test_zero_padding", padding = intArrayOf(1, 2))
+            )
+        )
+    }
+
+    @Test
+    fun zeroPadding2D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 3),
+                ZeroPadding2D(name = "test_zero_padding", padding = intArrayOf(1, 2, 3, 4), dataFormat = CHANNELS_LAST)
+            )
+        )
+    }
+
+    @Test
+    fun zeroPadding3D() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100, 100, 2),
+                ZeroPadding3D(name = "test_zero_padding", padding = intArrayOf(1, 2, 3, 4, 5, 6))
+            )
+        )
+    }
+
+    @Test
+    fun flatten() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100),
+                Flatten(name = "test_flatten")
+            )
+        )
+    }
+
+    @Test
+    fun permute() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(100, 100),
+                Permute(name = "test_permute", dims = intArrayOf(2, 1))
+            )
+        )
+    }
+
+    @Test
+    fun repeatVector() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(10),
+                RepeatVector(name = "test_repeat_vector", n = 2)
+            )
+        )
+    }
+
+    @Test
+    fun reshape() {
+        LayerImportExportTest.run(
+            Sequential.of(
+                Input(10),
+                Reshape(name = "test_reshape", targetShape = listOf(5, 5))
+            )
+        )
+    }
+}


### PR DESCRIPTION
This PR fixes various issues with importing and exporting layers configuration and adds missing weights import for `Conv1D`, `Conv3D` and `PReLU` layers. This is a step towards addressing #89.