### PR TITLE
Clamp input values to 0..255 range when converting FloatArray to a BufferedImage

### DIFF
--- a/dataset/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageConverter.kt
+++ b/dataset/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageConverter.kt
@@ -238,7 +238,7 @@ public object ImageConverter {
         outputShape: ImageShape,
         arrayColorMode: ColorMode,
         isNormalized: Boolean
-    ) : BufferedImage {
+    ): BufferedImage {
         return floatArrayToBufferedImage(inputArray, outputShape, arrayColorMode) {
             if (isNormalized) denormalizeInplace(it, scale = 255f) else it
         }
@@ -275,6 +275,11 @@ public object ImageConverter {
         require(
             numberOfElements == dataCopy.size.toLong()
         ) { "Requested output shape [$outputShape] does not match with input array size [${inputArray.size}]" }
+
+        for ((i, value) in dataCopy.withIndex()) {
+            if (value < 0) dataCopy[i] = 0f
+            if (value > 255) dataCopy[i] = 255f
+        }
 
         /* This swap is needed because BufferedImage.raster.setPixels accepts data in RGB format */
         if (arrayColorMode == ColorMode.BGR) {

--- a/dataset/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageConverter.kt
+++ b/dataset/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageConverter.kt
@@ -269,25 +269,23 @@ public object ImageConverter {
         arrayColorMode: ColorMode,
         arrayTransform: ArrayTransform? = null
     ): BufferedImage {
-        val numberOfElements = outputShape.width!! * outputShape.height!! * arrayColorMode.channels
-
         val dataCopy = arrayTransform?.invoke(inputArray.copyOf()) ?: inputArray.copyOf()
 
+        val numberOfElements = outputShape.width!! * outputShape.height!! * arrayColorMode.channels
         require(
             numberOfElements == dataCopy.size.toLong()
         ) { "Requested output shape [$outputShape] does not match with input array size [${inputArray.size}]" }
-
-        val output = BufferedImage(
-            outputShape.width.toInt(),
-            outputShape.height.toInt(),
-            arrayColorMode.imageType()
-        )
 
         /* This swap is needed because BufferedImage.raster.setPixels accepts data in RGB format */
         if (arrayColorMode == ColorMode.BGR) {
             swapRandB(dataCopy)
         }
 
+        val output = BufferedImage(
+            outputShape.width.toInt(),
+            outputShape.height.toInt(),
+            arrayColorMode.imageType()
+        )
         output.raster.setPixels(0, 0, output.width, output.height, dataCopy)
 
         return output

--- a/dataset/src/test/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageConverterTest.kt
+++ b/dataset/src/test/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageConverterTest.kt
@@ -99,7 +99,12 @@ class ImageConverterTest {
     }
 
     private val imageTypes =
-        listOf(BufferedImage.TYPE_BYTE_GRAY, BufferedImage.TYPE_3BYTE_BGR, BufferedImage.TYPE_INT_BGR, BufferedImage.TYPE_INT_RGB)
+        listOf(
+            BufferedImage.TYPE_BYTE_GRAY,
+            BufferedImage.TYPE_3BYTE_BGR,
+            BufferedImage.TYPE_INT_BGR,
+            BufferedImage.TYPE_INT_RGB
+        )
 
     @Test
     fun normalizedFloatArrayToBufferedImageTest() {
@@ -161,5 +166,27 @@ class ImageConverterTest {
         }
     }
 
-    private fun gray(value : Float) = byteArrayOf((value * 255).toInt().toByte())
+    @Test
+    fun floatArrayToBufferedImageClampTest() {
+        val colorMode = ColorMode.RGB
+        val expectedImage = BufferedImage(2, 2, colorMode.imageType())
+        expectedImage.setRGB(0, 0, Color.black.rgb)
+        expectedImage.setRGB(0, 1, Color.white.rgb)
+        expectedImage.setRGB(1, 0, Color.black.rgb)
+        expectedImage.setRGB(1, 1, Color.white.rgb)
+
+        val inputArray = FloatArray(expectedImage.width * expectedImage.height * colorMode.channels)
+        inputArray.fill(-5f, 0, inputArray.size / 2)
+        inputArray.fill(300f, inputArray.size / 2, inputArray.size)
+
+        val outputImage = ImageConverter.floatArrayToBufferedImage(
+            inputArray, expectedImage.getShape(), colorMode, false
+        )
+        Assertions.assertArrayEquals(
+            ImageConverter.toRawFloatArray(expectedImage),
+            ImageConverter.toRawFloatArray(outputImage),
+        )
+    }
+
+    private fun gray(value: Float) = byteArrayOf((value * 255).toInt().toByte())
 }


### PR DESCRIPTION
Fixes #377 