### PR TITLE
Simplify api for building Layers

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Functional.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Functional.kt
@@ -256,7 +256,7 @@ public class Functional(vararg layers: Layer) : GraphTrainableModel(*layers) {
 
     override fun buildLayers() {
         inputLayer.build(tf)
-        inputLayer.computeOutputShape()
+        inputLayer.setOutputShape(inputLayer.computeOutputShape())
 
         layers.filter { it !is Input }.forEach { layer ->
             layer.buildFromInboundLayers(tf)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Functional.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Functional.kt
@@ -97,7 +97,7 @@ public class Functional(vararg layers: Layer) : GraphTrainableModel(*layers) {
             if (topModel is Sequential && layers.size > 1) {
                 // establish edges in DAG
                 topLayers.subList(1, topLayers.size).forEachIndexed { index, layer ->
-                    val topLayersIndex = index - 1 + 1 
+                    val topLayersIndex = index - 1 + 1
                     // shift -1 to take previous, but shift +1 because it's an index in subList, started from 1
                     layer.inboundLayers.add(topLayers[topLayersIndex])
                 }
@@ -255,13 +255,11 @@ public class Functional(vararg layers: Layer) : GraphTrainableModel(*layers) {
     }
 
     override fun buildLayers() {
-        inputLayer.build(tf)
-        inputLayer.setOutputShape(inputLayer.computeOutputShape())
+        inputLayer.setOutputShape(inputLayer.build(tf))
 
         layers.filter { it !is Input }.forEach { layer ->
             val inputShapes = layer.inboundLayers.map { it.outputShape.toShape() }
-            layer.build(tf, inputShapes)
-            val outputShape = layer.computeOutputShape(inputShapes)
+            val outputShape = layer.build(tf, inputShapes)
             layer.setOutputShape(outputShape)
             logger.debug { "${layer.name}; $layer; outputShape: $outputShape" }
         }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Functional.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Functional.kt
@@ -259,8 +259,9 @@ public class Functional(vararg layers: Layer) : GraphTrainableModel(*layers) {
         inputLayer.setOutputShape(inputLayer.computeOutputShape())
 
         layers.filter { it !is Input }.forEach { layer ->
-            layer.buildFromInboundLayers(tf)
-            val outputShape = layer.computeOutputShapeFromInboundLayers()
+            val inputShapes = layer.inboundLayers.map { it.outputShape.toShape() }
+            layer.build(tf, inputShapes)
+            val outputShape = layer.computeOutputShape(inputShapes)
             layer.setOutputShape(outputShape)
             logger.debug { "${layer.name}; $layer; outputShape: $outputShape" }
         }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Sequential.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Sequential.kt
@@ -142,18 +142,13 @@ public class Sequential(vararg layers: Layer) : GraphTrainableModel(*layers) {
     }
 
     override fun buildLayers(training: Operand<Boolean>, numberOfLosses: Operand<Float>): Pair<Placeholder<Float>, Operand<Float>> {
-        var inputShape = inputLayer.build(tf)
-        inputLayer.setOutputShape(inputShape)
-        val input = inputLayer.input
-        var output = inputLayer.forward(tf, input, training, numberOfLossesOp)
+        val input = inputLayer.build(tf)
+        inputLayer.setOutputShape(input.asOutput().shape())
+        var output: Operand<Float> = input
 
         layers.filter { it !is Input }.forEach { layer ->
-            inputShape = layer.build(tf, inputShape)
-
-            layer.setOutputShape(inputShape)
-            logger.debug { "${layer.name}; $layer; outputShape: $inputShape" }
-
-            output = layer.forward(tf, output, training, numberOfLossesOp)
+            output = layer.build(tf, output, training, numberOfLossesOp)
+            layer.setOutputShape(output.asOutput().shape())
         }
 
         return input to output

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Sequential.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Sequential.kt
@@ -141,14 +141,12 @@ public class Sequential(vararg layers: Layer) : GraphTrainableModel(*layers) {
     }
 
     override fun buildLayers() {
-        inputLayer.build(tf)
-        var inputShape = inputLayer.computeOutputShape()
+        var inputShape = inputLayer.build(tf)
         inputLayer.setOutputShape(inputShape)
 
         layers.filter { it !is Input }.forEach { layer ->
-            layer.build(tf, inputShape)
+            inputShape = layer.build(tf, inputShape)
 
-            inputShape = layer.computeOutputShape(inputShape)
             layer.setOutputShape(inputShape)
             logger.debug { "${layer.name}; $layer; outputShape: $inputShape" }
         }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Sequential.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Sequential.kt
@@ -144,7 +144,8 @@ public class Sequential(vararg layers: Layer) : GraphTrainableModel(*layers) {
 
     override fun buildLayers() {
         inputLayer.build(tf)
-        var inputShape: Shape = inputLayer.computeOutputShape()
+        var inputShape = inputLayer.computeOutputShape()
+        inputLayer.setOutputShape(inputShape)
 
         layers.filter { it !is Input }.forEach { layer ->
             layer.build(tf, inputShape)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Sequential.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/Sequential.kt
@@ -9,10 +9,8 @@ import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
 import org.jetbrains.kotlinx.dl.api.core.layer.setOutputShape
 import org.jetbrains.kotlinx.dl.api.core.layer.weights
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.keras.*
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import java.io.File
 import java.io.FileNotFoundException
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
@@ -30,39 +30,26 @@ public abstract class Layer(public var name: String) {
     public var outboundLayers: MutableList<Layer> = mutableListOf()
 
     /**
-     * Extend this function to define variables in layer.
+     * Extend this function to define variables in layer and compute output shape.
      *
      * @param [tf] TensorFlow graph API for building operations.
-     * @param [inputShape] Input shape, result of [computeOutputShape] call from previous layer.
+     * @param [inputShape] Shape of the input from previous layer.
+     * @returns output shape, based on [inputShape] and [Layer] type.
      */
-    public abstract fun build(tf: Ops, inputShape: Shape)
+    public abstract fun build(tf: Ops, inputShape: Shape): Shape
 
     /**
-     * Extend this function to define variables in layer.
+     * Extend this function to define variables in layer and compute output shape.
      *
      * NOTE: This function should be overridden for layers with multiple inputs.
      * NOTE: Used in Functional API
      *
      * @param [tf] TensorFlow graph API for building operations.
-     * @param [inputShapes] Shapes of the inputs, result of [computeOutputShape] call from inbound layers.
+     * @param [inputShapes] Shapes of the inputs, result of [build] calls from inbound layers.
+     * @returns output shape, based on [inputShapes] and [Layer] type.
      */
-    public open fun build(tf: Ops, inputShapes: List<Shape>) {
-        build(tf, inputShapes.first())
-    }
-
-    /**
-     * Computes output shape, based on [inputShape] and [Layer] type.
-     */
-    public abstract fun computeOutputShape(inputShape: Shape): Shape
-
-    /**
-     * Computes output shape, based on [inputShapes] and [Layer] type.
-     *
-     * NOTE: This function should be overridden for layers with multiple inputs.
-     * NOTE: Used in Functional API
-     */
-    public open fun computeOutputShape(inputShapes: List<Shape>): Shape {
-        return computeOutputShape(inputShapes.first())
+    public open fun build(tf: Ops, inputShapes: List<Shape>): Shape {
+        return build(tf, inputShapes.first())
     }
 
     /**

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
@@ -30,48 +30,33 @@ public abstract class Layer(public var name: String) {
     public var outboundLayers: MutableList<Layer> = mutableListOf()
 
     /**
-     * Extend this function to define variables in layer and compute output shape.
+     * Extend this function to define variables in the layer and compute layer output.
      *
      * @param [tf] TensorFlow graph API for building operations.
-     * @param [inputShape] Shape of the input from previous layer.
-     * @returns output shape, based on [inputShape] and [Layer] type.
+     * @param [input] Layer input.
+     * @param [isTraining] TensorFlow operand for switching between training and inference modes.
+     * @param [numberOfLosses] TensorFlow operand for batch size data.
      */
-    public abstract fun build(tf: Ops, inputShape: Shape): Shape
+    public abstract fun build(tf: Ops,
+                              input: Operand<Float>,
+                              isTraining: Operand<Boolean>,
+                              numberOfLosses: Operand<Float>?): Operand<Float>
 
     /**
-     * Extend this function to define variables in layer and compute output shape.
+     * Extend this function to define variables in the layer and compute layer output.
      *
      * NOTE: This function should be overridden for layers with multiple inputs.
      * NOTE: Used in Functional API
      *
-     * @param [tf] TensorFlow graph API for building operations.
-     * @param [inputShapes] Shapes of the inputs, result of [build] calls from inbound layers.
-     * @returns output shape, based on [inputShapes] and [Layer] type.
+     * @param [input] Layer input list.
+     * @param [isTraining] TensorFlow operand for switching between training and inference modes.
+     * @param [numberOfLosses] TensorFlow operand for batch size data.
      */
-    public open fun build(tf: Ops, inputShapes: List<Shape>): Shape {
-        return build(tf, inputShapes.first())
-    }
-
-    /**
-     * Builds main layer input transformation with [tf]. Depends on [Layer] type.
-     */
-    public abstract fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
-    ): Operand<Float>
-
-    /**
-     * Builds main layer input transformation with [tf]. Depends on [Layer] type.
-     */
-    public open fun forward(
-        tf: Ops,
-        input: List<Operand<Float>>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
-    ): Operand<Float> {
-        return forward(tf, input[0], isTraining, numberOfLosses)
+    public open fun build(tf: Ops,
+                          input: List<Operand<Float>>,
+                          isTraining: Operand<Boolean>,
+                          numberOfLosses: Operand<Float>?): Operand<Float> {
+        return build(tf, input.first(), isTraining, numberOfLosses)
     }
 
     /** Important part of functional API. It takes [layers] as input and saves them to the [inboundLayers] of the given layer. */

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/AbstractActivationLayer.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/AbstractActivationLayer.kt
@@ -43,10 +43,7 @@ public abstract class AbstractActivationLayer(name: String) : Layer(name) {
 
     override fun build(tf: Ops, inputShape: Shape): Unit = Unit
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
-        this.outputShape = TensorShape(inputShape)
-        return inputShape
-    }
+    override fun computeOutputShape(inputShape: Shape): Shape = inputShape
 
     override val hasActivation: Boolean get() = true
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/AbstractActivationLayer.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/AbstractActivationLayer.kt
@@ -6,9 +6,7 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.activation
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -34,14 +32,12 @@ public abstract class AbstractActivationLayer(name: String) : Layer(name) {
         input: Operand<Float>
     ): Operand<Float>
 
-    override fun forward(
+    override fun build(
         tf: Ops,
         input: Operand<Float>,
         isTraining: Operand<Boolean>,
         numberOfLosses: Operand<Float>?
     ): Operand<Float> = forward(tf, input)
-
-    override fun build(tf: Ops, inputShape: Shape): Shape = inputShape
 
     override val hasActivation: Boolean get() = true
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/AbstractActivationLayer.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/AbstractActivationLayer.kt
@@ -41,9 +41,7 @@ public abstract class AbstractActivationLayer(name: String) : Layer(name) {
         numberOfLosses: Operand<Float>?
     ): Operand<Float> = forward(tf, input)
 
-    override fun build(tf: Ops, inputShape: Shape): Unit = Unit
-
-    override fun computeOutputShape(inputShape: Shape): Shape = inputShape
+    override fun build(tf: Ops, inputShape: Shape): Shape = inputShape
 
     override val hasActivation: Boolean get() = true
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/PReLU.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/PReLU.kt
@@ -51,7 +51,7 @@ public class PReLU(
 
     override var isTrainable: Boolean = true
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         val alphaShapeArray = inputShape.toLongArray().drop(1).toLongArray()
         if (sharedAxes != null) {
             for (axis in sharedAxes) {
@@ -72,6 +72,8 @@ public class PReLU(
             alphaInitializer,
             alphaRegularizer
         )
+
+        return super.build(tf, inputShape)
     }
 
     override fun forward(tf: Ops, input: Operand<Float>): Operand<Float> {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/PReLU.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/activation/PReLU.kt
@@ -51,7 +51,8 @@ public class PReLU(
 
     override var isTrainable: Boolean = true
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
+    override fun forward(tf: Ops, input: Operand<Float>): Operand<Float> {
+        val inputShape = input.asOutput().shape()
         val alphaShapeArray = inputShape.toLongArray().drop(1).toLongArray()
         if (sharedAxes != null) {
             for (axis in sharedAxes) {
@@ -73,10 +74,6 @@ public class PReLU(
             alphaRegularizer
         )
 
-        return super.build(tf, inputShape)
-    }
-
-    override fun forward(tf: Ops, input: Operand<Float>): Operand<Float> {
         // It's equivalent to: `-alpha * relu(-x) + relu(x)`
         val positive = tf.nn.relu(input)
         val negative = tf.math.mul(tf.math.neg(alpha.variable), tf.nn.relu(tf.math.neg(input)))

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlinx.dl.api.core.activation.Activations
 import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
 import org.jetbrains.kotlinx.dl.api.core.layer.*
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
 import org.tensorflow.Operand
 import org.tensorflow.Shape
@@ -65,7 +64,7 @@ public abstract class AbstractConv(
     public override val variables: List<KVariable>
         get() = listOfNotNull(kernel, bias)
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         // Amount of channels should be the last value in the inputShape
         val numberOfChannels = inputShape.size(inputShape.numDimensions() - 1)
 
@@ -96,6 +95,7 @@ public abstract class AbstractConv(
                 biasRegularizer
             )
         }
+        return computeOutputShape(inputShape)
     }
 
     override fun forward(
@@ -143,6 +143,9 @@ public abstract class AbstractConv(
 
     /** The actual layer operation implementation without adding the bias which is added by the abstract class. */
     protected abstract fun convImplementation(tf: Ops, input: Operand<Float>): Operand<Float>
+
+    /** Given [inputShape] return output shape.*/
+    protected abstract fun computeOutputShape(inputShape: Shape): Shape
 }
 
 private fun multiply(values: LongArray) = values.fold(1L, Long::times)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -98,12 +98,6 @@ public abstract class AbstractConv(
         }
     }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
-        val shape = defineOutputShape(inputShape)
-        outputShape = TensorShape(shape)
-        return shape
-    }
-
     override fun forward(
         tf: Ops,
         input: Operand<Float>,
@@ -149,15 +143,6 @@ public abstract class AbstractConv(
 
     /** The actual layer operation implementation without adding the bias which is added by the abstract class. */
     protected abstract fun convImplementation(tf: Ops, input: Operand<Float>): Operand<Float>
-
-    /**
-     * Actual implementation of [computeOutputShape] which only defines the value
-     * of output shape without the need of saving it to some variable.
-     *
-     * @param inputShape which can be used to define the output shape
-     * @return the defined output shape that is saved in class variable and returned by [computeOutputShape]]
-     */
-    protected abstract fun defineOutputShape(inputShape: Shape): Shape
 }
 
 private fun multiply(values: LongArray) = values.fold(1L, Long::times)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
@@ -127,7 +127,7 @@ public class Conv1D(
         }
     }
 
-    protected override fun defineOutputShape(inputShape: Shape): Shape {
+    override fun computeOutputShape(inputShape: Shape): Shape {
         val batchSize = inputShape.size(0)
         val colsCount = inputShape.size(1)
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
@@ -14,11 +14,9 @@ import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.jetbrains.kotlinx.dl.api.core.util.convBiasVarName
 import org.jetbrains.kotlinx.dl.api.core.util.convKernelVarName
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.core.Squeeze
 import org.tensorflow.op.nn.Conv2d
@@ -125,21 +123,6 @@ public class Conv1D(
                 padding.paddingName, options
             )
         }
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
-        val batchSize = inputShape.size(0)
-        val colsCount = inputShape.size(1)
-
-        val cols = convOutputLength(
-            colsCount,
-            kernelLength,
-            padding,
-            strides[1],
-            dilations[1]
-        )
-
-        return Shape.make(batchSize, cols, filters.toLong())
     }
 
     override fun toString(): String {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1DTranspose.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.wi
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.tensorflow.Operand
 import org.tensorflow.op.Ops
 
@@ -81,6 +82,7 @@ public class Conv1DTranspose(
     override val kernelSize: IntArray = intArrayOf(kernelLength)
 
     override fun convImplementation(tf: Ops, input: Operand<Float>): Operand<Float> {
+        val outputShape = TensorShape(computeOutputShape(input.asOutput().shape()))
         // implementation of a 1D convolution with a 2D convolution
         return tf.withExpandedDimensions(input) { expandedInput ->
             // expand 1D convolution parameters to use them with a 2D convolution operation

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
@@ -120,7 +120,7 @@ public class Conv2D(
         )
     }
 
-    protected override fun defineOutputShape(inputShape: Shape): Shape {
+    override fun computeOutputShape(inputShape: Shape): Shape {
         val batchSize = inputShape.size(0)
         val rowsCount = inputShape.size(1)
         val colsCount = inputShape.size(2)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
@@ -13,11 +13,9 @@ import org.jetbrains.kotlinx.dl.api.core.layer.TrainableLayer
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.jetbrains.kotlinx.dl.api.core.util.convBiasVarName
 import org.jetbrains.kotlinx.dl.api.core.util.convKernelVarName
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.nn.Conv2d.dilations
 
@@ -118,29 +116,6 @@ public class Conv2D(
             padding.paddingName,
             options
         )
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
-        val batchSize = inputShape.size(0)
-        val rowsCount = inputShape.size(1)
-        val colsCount = inputShape.size(2)
-
-        val rows = convOutputLength(
-            rowsCount,
-            kernelSize[0],
-            padding,
-            strides[1],
-            dilations[1]
-        )
-        val cols = convOutputLength(
-            colsCount,
-            kernelSize[1],
-            padding,
-            strides[2],
-            dilations[2]
-        )
-
-        return Shape.make(batchSize, rows, cols, filters.toLong())
     }
 
     override fun kernelVarName(name: String): String = convKernelVarName(name, dim = 2)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2DTranspose.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.tensorflow.Operand
 import org.tensorflow.op.Ops
 
@@ -107,6 +108,7 @@ public class Conv2DTranspose(
     }
 
     override fun convImplementation(tf: Ops, input: Operand<Float>): Operand<Float> {
+        val outputShape = TensorShape(computeOutputShape(input.asOutput().shape()))
         return tf.nn.conv2dBackpropInput(
             tf.shapeWithDynamicBatchSize(outputShape, input),
             kernel.variable,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
@@ -13,11 +13,9 @@ import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.jetbrains.kotlinx.dl.api.core.util.convBiasVarName
 import org.jetbrains.kotlinx.dl.api.core.util.convKernelVarName
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.nn.Conv3d.dilations
 
@@ -122,37 +120,6 @@ public class Conv3D(
             padding.paddingName,
             options
         )
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
-        val batchSize = inputShape.size(0)
-        val depthsCount = inputShape.size(1)
-        val rowsCount = inputShape.size(2)
-        val colsCount = inputShape.size(3)
-
-        val depths = convOutputLength(
-            depthsCount,
-            kernelSize[0],
-            padding,
-            strides[1],
-            dilations[1]
-        )
-        val rows = convOutputLength(
-            rowsCount,
-            kernelSize[1],
-            padding,
-            strides[2],
-            dilations[2]
-        )
-        val cols = convOutputLength(
-            colsCount,
-            kernelSize[2],
-            padding,
-            strides[3],
-            dilations[3]
-        )
-
-        return Shape.make(batchSize, depths, rows, cols, filters.toLong())
     }
 
     override fun toString(): String {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
@@ -124,7 +124,7 @@ public class Conv3D(
         )
     }
 
-    protected override fun defineOutputShape(inputShape: Shape): Shape {
+    override fun computeOutputShape(inputShape: Shape): Shape {
         val batchSize = inputShape.size(0)
         val depthsCount = inputShape.size(1)
         val rowsCount = inputShape.size(2)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3DTranspose.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.tensorflow.Operand
 import org.tensorflow.op.Ops
 import org.tensorflow.op.nn.Conv3dBackpropInput
@@ -106,6 +107,7 @@ public class Conv3DTranspose(
     override val outputPadding: IntArray? get() = null
 
     override fun convImplementation(tf: Ops, input: Operand<Float>): Operand<Float> {
+        val outputShape = TensorShape(computeOutputShape(input.asOutput().shape()))
         val options = Conv3dBackpropInput.dilations(dilations.toLongList()).dataFormat("NDHWC")
         return tf.nn.conv3dBackpropInput(
             tf.shapeWithDynamicBatchSize(outputShape, input),

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
@@ -35,7 +35,7 @@ public abstract class ConvTranspose(
 
     protected abstract val outputPadding: IntArray?
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    protected fun computeOutputShape(inputShape: Shape): Shape {
         val shapes = (kernelSize.indices).map {
             convTransposeOutputLength(
                 inputShape.size(it + 1),

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
@@ -35,7 +35,7 @@ public abstract class ConvTranspose(
 
     protected abstract val outputPadding: IntArray?
 
-    override fun defineOutputShape(inputShape: Shape): Shape {
+    override fun computeOutputShape(inputShape: Shape): Shape {
         val shapes = (kernelSize.indices).map {
             convTransposeOutputLength(
                 inputShape.size(it + 1),

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongArray
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
 import org.jetbrains.kotlinx.dl.api.core.util.depthwiseConv2dBiasVarName
 import org.jetbrains.kotlinx.dl.api.core.util.depthwiseConv2dKernelVarName
@@ -125,31 +124,6 @@ public class DepthwiseConv2D(
     ): Operand<Float> {
         val options = DepthwiseConv2dNative.dilations(dilations.toLongList()).dataFormat("NHWC")
         return tf.nn.depthwiseConv2dNative(input, kernel.variable, strides.toLongList(), padding.paddingName, options)
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
-        val batchSize = inputShape.size(0)
-        val rowsCount = inputShape.size(1)
-        val colsCount = inputShape.size(2)
-        val channelsCount = inputShape.size(3)
-
-        val rows = convOutputLength(
-            rowsCount,
-            kernelSize[0],
-            padding,
-            strides[1],
-            dilations[1]
-        )
-        val cols = convOutputLength(
-            colsCount,
-            kernelSize[1],
-            padding,
-            strides[2],
-            dilations[2]
-        )
-        val filters = channelsCount * depthMultiplier
-
-        return Shape.make(batchSize, rows, cols, filters)
     }
 
     override fun toString(): String {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
@@ -127,7 +127,7 @@ public class DepthwiseConv2D(
         return tf.nn.depthwiseConv2dNative(input, kernel.variable, strides.toLongList(), padding.paddingName, options)
     }
 
-    override fun defineOutputShape(inputShape: Shape): Shape {
+    override fun computeOutputShape(inputShape: Shape): Shape {
         val batchSize = inputShape.size(0)
         val rowsCount = inputShape.size(1)
         val colsCount = inputShape.size(2)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/SeparableConv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/SeparableConv2D.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
 import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
 import org.jetbrains.kotlinx.dl.api.core.layer.*
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
 import org.jetbrains.kotlinx.dl.api.core.util.separableConv2dBiasVarName
@@ -183,9 +182,7 @@ public class SeparableConv2D(
             strides[2], dilations[2]
         )
 
-        val shape = Shape.make(inputShape.size(0), rows, cols, filters.toLong())
-        outputShape = TensorShape(shape)
-        return shape
+        return Shape.make(inputShape.size(0), rows, cols, filters.toLong())
     }
 
     override fun forward(

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/SeparableConv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/SeparableConv2D.kt
@@ -125,7 +125,7 @@ public class SeparableConv2D(
         requireArraySize(dilations, 4, "dilations")
     }
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         // Amount of channels should be the last value in the inputShape (make warning here)
         val numberOfChannels = inputShape.size(inputShape.numDimensions() - 1)
 
@@ -168,9 +168,7 @@ public class SeparableConv2D(
                 biasRegularizer
             )
         }
-    }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
         var rows = inputShape.size(1)
         var cols = inputShape.size(2)
         rows = convOutputLength(

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Dense.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Dense.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.TrainableLayer
 import org.jetbrains.kotlinx.dl.api.core.layer.createVariable
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.util.denseBiasVarName
 import org.jetbrains.kotlinx.dl.api.core.util.denseKernelVarName
 import org.tensorflow.Operand
@@ -62,7 +61,12 @@ public class Dense(
 
     override var isTrainable: Boolean = true
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
+    ): Operand<Float> {
+        val inputShape = input.asOutput().shape()
         val fanIn = inputShape.size(inputShape.numDimensions() - 1).toInt()
         val fanOut = outputSize
 
@@ -89,15 +93,7 @@ public class Dense(
                 biasRegularizer
             )
         }
-        return TensorShape(inputShape).replaceLast(outputSize.toLong()).toShape()
-    }
 
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
-    ): Operand<Float> {
         val matMul = tf.linalg.matMul(input, kernel.variable)
         val signal = bias?.let { tf.math.add(matMul, it.variable) } ?: matMul
         return Activations.convert(activation).apply(tf, signal, name)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Dense.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Dense.kt
@@ -62,7 +62,7 @@ public class Dense(
 
     override var isTrainable: Boolean = true
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         val fanIn = inputShape.size(inputShape.numDimensions() - 1).toInt()
         val fanOut = outputSize
 
@@ -89,9 +89,6 @@ public class Dense(
                 biasRegularizer
             )
         }
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
         return TensorShape(inputShape).replaceLast(outputSize.toLong()).toShape()
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Input.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Input.kt
@@ -28,7 +28,12 @@ public class Input(vararg dims: Long, name: String = "") : Layer(name) {
     /** Input data dimensions. Rank = 3 or 4 for most popular supported cases. */
     public var packedDims: LongArray = dims
 
-    override fun build(tf: Ops, inputShape: Shape): Shape = build(tf)
+    override fun build(
+        tf: Ops,
+        input: Operand<Float>,
+        isTraining: Operand<Boolean>,
+        numberOfLosses: Operand<Float>?
+    ): Operand<Float> = build(tf)
 
     /**
      * Extend this function to define placeholder in layer.
@@ -37,20 +42,11 @@ public class Input(vararg dims: Long, name: String = "") : Layer(name) {
      *
      * @param [tf] TensorFlow graph API for building operations.
      */
-    public fun build(tf: Ops): Shape {
+    public fun build(tf: Ops): Placeholder<Float> {
         input = tf.withName(DATA_PLACEHOLDER).placeholder(
             getDType(),
             Placeholder.shape(Shape.make(-1L, *packedDims))
         )
-        return input.asOutput().shape()
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
-    ): Operand<Float> {
         return input
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Input.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Input.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.core
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.util.DATA_PLACEHOLDER
 import org.jetbrains.kotlinx.dl.api.core.util.getDType
 import org.tensorflow.Operand
@@ -29,7 +28,7 @@ public class Input(vararg dims: Long, name: String = "") : Layer(name) {
     /** Input data dimensions. Rank = 3 or 4 for most popular supported cases. */
     public var packedDims: LongArray = dims
 
-    override fun build(tf: Ops, inputShape: Shape) {}
+    override fun build(tf: Ops, inputShape: Shape): Shape = build(tf)
 
     /**
      * Extend this function to define placeholder in layer.
@@ -38,19 +37,13 @@ public class Input(vararg dims: Long, name: String = "") : Layer(name) {
      *
      * @param [tf] TensorFlow graph API for building operations.
      */
-    public fun build(tf: Ops) {
+    public fun build(tf: Ops): Shape {
         input = tf.withName(DATA_PLACEHOLDER).placeholder(
             getDType(),
             Placeholder.shape(Shape.make(-1L, *packedDims))
         )
+        return input.asOutput().shape()
     }
-
-    /**
-     * Computes output shape, based on [input] and [Layer] type.
-     *
-     * NOTE: Called instead of [Layer.computeOutputShape].
-     */
-    public fun computeOutputShape(): Shape = input.asOutput().shape()
 
     override fun forward(
         tf: Ops,
@@ -59,10 +52,6 @@ public class Input(vararg dims: Long, name: String = "") : Layer(name) {
         numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return input
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
-        return inputShape
     }
 
     override val hasActivation: Boolean get() = false

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Input.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Input.kt
@@ -50,10 +50,7 @@ public class Input(vararg dims: Long, name: String = "") : Layer(name) {
      *
      * NOTE: Called instead of [Layer.computeOutputShape].
      */
-    public fun computeOutputShape(): Shape {
-        outputShape = TensorShape(input.asOutput().shape())
-        return outputShape.toShape()
-    }
+    public fun computeOutputShape(): Shape = input.asOutput().shape()
 
     override fun forward(
         tf: Ops,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
@@ -24,7 +24,7 @@ public abstract class AbstractMerge(public val layerTypeName: String, name: Stri
     }
 
     override fun computeOutputShape(inputShape: Shape): Shape {
-        throw UnsupportedOperationException("This layer is not supported for Sequential model!")
+        throw UnsupportedOperationException("$layerTypeName layer is not supported in Sequential models.")
     }
 
     override fun computeOutputShapeFromInboundLayers(): TensorShape {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.merge
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.core.shape.copy
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
@@ -27,9 +28,9 @@ public abstract class AbstractMerge(public val layerTypeName: String, name: Stri
         throw UnsupportedOperationException("$layerTypeName layer is not supported in Sequential models.")
     }
 
-    override fun computeOutputShapeFromInboundLayers(): TensorShape {
-        checkInputShapes(inboundLayers.map { it.outputShape.toShape() }) //TODO: crash efficientNet models
-        return inboundLayers[0].outputShape.clone()
+    override fun computeOutputShape(inputShapes: List<Shape>): Shape {
+        checkInputShapes(inputShapes) //TODO: crash efficientNet models
+        return inputShapes.first().copy()
     }
 
     override fun forward(

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.merge
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
-import org.jetbrains.kotlinx.dl.api.core.shape.copy
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
@@ -20,29 +19,18 @@ import org.tensorflow.op.Ops
  * @property [layerTypeName] Specified layer name used for tf operation alias building.
  */
 public abstract class AbstractMerge(public val layerTypeName: String, name: String = "") : Layer(name) {
-    override fun build(tf: Ops, inputShape: Shape): Shape {
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
+    ): Operand<Float> {
         throw UnsupportedOperationException("$layerTypeName is not supported in Sequential models.")
     }
 
-    override fun build(tf: Ops, inputShapes: List<Shape>): Shape {
-        checkInputShapes(inputShapes) //TODO: crash efficientNet models
-        return inputShapes.first().copy()
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
-    ): Operand<Float> {
-        return input
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: List<Operand<Float>>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: List<Operand<Float>>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         checkInputShapes(input.map { it.asOutput().shape() }) //TODO: crash efficientNet models
         return tf.withName(layerTypeName).identity(mergeFunction(input, tf))

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
@@ -28,7 +28,7 @@ public abstract class AbstractMerge(public val layerTypeName: String, name: Stri
     }
 
     override fun computeOutputShapeFromInboundLayers(): TensorShape {
-        checkInputShapesOfInboundLayers() //TODO: crash efficientNet models
+        checkInputShapes(inboundLayers.map { it.outputShape.toShape() }) //TODO: crash efficientNet models
         return inboundLayers[0].outputShape.clone()
     }
 
@@ -47,7 +47,7 @@ public abstract class AbstractMerge(public val layerTypeName: String, name: Stri
         isTraining: Operand<Boolean>,
         numberOfLosses: Operand<Float>?
     ): Operand<Float> {
-        checkInputShapesOfInputOperands(input) //TODO: crash efficientNet models
+        checkInputShapes(input.map { it.asOutput().shape() }) //TODO: crash efficientNet models
         return tf.withName(layerTypeName).identity(mergeFunction(input, tf))
     }
 
@@ -57,30 +57,15 @@ public abstract class AbstractMerge(public val layerTypeName: String, name: Stri
         tf: Ops
     ): Operand<Float>
 
-    /** Checks input shapes of input operands. */
-    protected open fun checkInputShapesOfInputOperands(input: List<Operand<Float>>) {
-        require(input.size > 1) { "The number of input layers should be more than 1." }
-
-        val firstInputShape = TensorShape(input[0].asOutput().shape())
-
-        for (layer in input) {
-            val tensorShape = TensorShape(
-                layer.asOutput().shape()
-            )
-            require(
-                firstInputShape == tensorShape
-            ) { "The shape of first input $firstInputShape should be equal to the shape $tensorShape of $layer " }
-        }
-    }
-
-    private fun checkInputShapesOfInboundLayers() {
-        val firstInputShape = inboundLayers[0].outputShape
-
-        for (layer in inboundLayers) {
-            val tensorShape = layer.outputShape
-            require(
-                firstInputShape == tensorShape
-            ) { "The shape of first input $firstInputShape should be equal to the shape $tensorShape of $layer " }
+    /** Checks shapes of input operands. */
+    protected open fun checkInputShapes(inputShapes: List<Shape>) {
+        require(inputShapes.size > 1) { "The number of input layers should be more than 1." }
+        val firstInputShape = TensorShape(inputShapes.first())
+        for ((index, inputShape) in inputShapes.withIndex()) {
+            val currentInputShape = TensorShape(inputShape)
+            require(firstInputShape == currentInputShape) {
+                "The shape of first input $firstInputShape should be equal to the shape $currentInputShape at input index $index."
+            }
         }
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
@@ -29,8 +29,7 @@ public abstract class AbstractMerge(public val layerTypeName: String, name: Stri
 
     override fun computeOutputShapeFromInboundLayers(): TensorShape {
         checkInputShapesOfInboundLayers() //TODO: crash efficientNet models
-        outputShape = inboundLayers[0].outputShape.clone()
-        return outputShape
+        return inboundLayers[0].outputShape.clone()
     }
 
     override fun forward(

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/AbstractMerge.kt
@@ -20,15 +20,11 @@ import org.tensorflow.op.Ops
  * @property [layerTypeName] Specified layer name used for tf operation alias building.
  */
 public abstract class AbstractMerge(public val layerTypeName: String, name: String = "") : Layer(name) {
-    override fun build(tf: Ops, inputShape: Shape) {
-
+    override fun build(tf: Ops, inputShape: Shape): Shape {
+        throw UnsupportedOperationException("$layerTypeName is not supported in Sequential models.")
     }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
-        throw UnsupportedOperationException("$layerTypeName layer is not supported in Sequential models.")
-    }
-
-    override fun computeOutputShape(inputShapes: List<Shape>): Shape {
+    override fun build(tf: Ops, inputShapes: List<Shape>): Shape {
         checkInputShapes(inputShapes) //TODO: crash efficientNet models
         return inputShapes.first().copy()
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/Concatenate.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/Concatenate.kt
@@ -25,7 +25,7 @@ public class Concatenate(
     public var axis: Int = 3,
     name: String = ""
 ) : AbstractMerge("ConcatenateLayer", name), NoGradients {
-    override fun computeOutputShape(inputShapes: List<Shape>): Shape {
+    override fun build(tf: Ops, inputShapes: List<Shape>): Shape {
         val newShapeArray = inputShapes.first().toLongArray()
 
         var axe = axis.takeIf { it != -1 /*it influences on nasmobilemodel*/ }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/Concatenate.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/Concatenate.kt
@@ -36,9 +36,7 @@ public class Concatenate(
 
         newShape[axe] = inputShapes.sumOf { it[axe] } // concatenated dimension
 
-        val tensorShape = newShape.clone()
-        outputShape = tensorShape
-        return tensorShape
+        return newShape.clone()
     }
 
     override fun checkInputShapesOfInputOperands(input: List<Operand<Float>>) {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/Concatenate.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/Concatenate.kt
@@ -7,8 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.merge
 
 import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
-import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
-import org.jetbrains.kotlinx.dl.api.core.shape.toLongArray
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
@@ -25,17 +23,6 @@ public class Concatenate(
     public var axis: Int = 3,
     name: String = ""
 ) : AbstractMerge("ConcatenateLayer", name), NoGradients {
-    override fun build(tf: Ops, inputShapes: List<Shape>): Shape {
-        val newShapeArray = inputShapes.first().toLongArray()
-
-        var axe = axis.takeIf { it != -1 /*it influences on nasmobilemodel*/ }
-            ?: newShapeArray.size + axis // to make axe positive
-
-        newShapeArray[axe] = inputShapes.sumOf { it.size(axe) } // concatenated dimension
-
-        return shapeFromDims(*newShapeArray)
-    }
-
     override fun checkInputShapes(inputShapes: List<Shape>) {
         require(inputShapes.size > 1) { "The number of input layers should be more than 1." }
         val firstInputShape = TensorShape(inputShapes.first())

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/Concatenate.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/merge/Concatenate.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.merge
 import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.tensorflow.Operand
+import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -39,20 +40,14 @@ public class Concatenate(
         return newShape.clone()
     }
 
-    override fun checkInputShapesOfInputOperands(input: List<Operand<Float>>) {
-        require(input.size > 1) { "The number of input layers should be more than 1." }
-
-        val firstInputShape = TensorShape(input[0].asOutput().shape())
-
-        for (layer in input) {
-            val tensorShape = TensorShape(
-                layer.asOutput().shape()
-            )
-            require(
-                firstInputShape.almostEqual(tensorShape, except = axis)
-            ) {
-                "A Concatenate layer requires inputs with matching shapes except for the concat axis. " +
-                        "But shapes are the following: shape of first input is $firstInputShape and shape of layer $layer is $tensorShape."
+    override fun checkInputShapes(inputShapes: List<Shape>) {
+        require(inputShapes.size > 1) { "The number of input layers should be more than 1." }
+        val firstInputShape = TensorShape(inputShapes.first())
+        for ((index, inputShape)  in inputShapes.withIndex()) {
+            val currentInputShape = TensorShape(inputShape)
+            require(firstInputShape.almostEqual(currentInputShape, except = axis)) {
+                "A Concatenate layer requires inputs with matching shapes except for the concat axis $axis. " +
+                        "But shapes are the following: shape of first input is $firstInputShape and shape at index $index is $currentInputShape."
             }
         }
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/normalization/BatchNorm.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/normalization/BatchNorm.kt
@@ -60,7 +60,7 @@ public class BatchNorm(
     override val variables: List<KVariable>
         get() = listOfNotNull(gamma, beta, movingMean, movingVariance)
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         // Compute shapes of kernel and bias matrices
         val weightShape = Shape.make(inputShape.size(axis[0]))
 
@@ -112,9 +112,6 @@ public class BatchNorm(
                 betaRegularizer
             )
         }
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
         return inputShape
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/normalization/BatchNorm.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/normalization/BatchNorm.kt
@@ -60,7 +60,12 @@ public class BatchNorm(
     override val variables: List<KVariable>
         get() = listOfNotNull(gamma, beta, movingMean, movingVariance)
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
+    ): Operand<Float> {
+        val inputShape = input.asOutput().shape()
         // Compute shapes of kernel and bias matrices
         val weightShape = Shape.make(inputShape.size(axis[0]))
 
@@ -112,15 +117,7 @@ public class BatchNorm(
                 betaRegularizer
             )
         }
-        return inputShape
-    }
 
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
-    ): Operand<Float> {
         val tf = tf.withName("BatchNorm")
         return batchNorm(
             tf,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool1D.kt
@@ -56,9 +56,7 @@ public class AvgPool1D(
         }
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Unit = Unit
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         var steps = inputShape.size(1)
         steps = convOutputLength(steps, poolSize[1], padding, strides[1])
         return Shape.make(inputShape.size(0), steps, inputShape.size(2))

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool1D.kt
@@ -8,9 +8,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.core.Squeeze
 
@@ -56,17 +54,10 @@ public class AvgPool1D(
         }
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        var steps = inputShape.size(1)
-        steps = convOutputLength(steps, poolSize[1], padding, strides[1])
-        return Shape.make(inputShape.size(0), steps, inputShape.size(2))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         val expandAxis = 2
         val tfInput = tf.expandDims(input, tf.constant(expandAxis))

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool2D.kt
@@ -43,9 +43,7 @@ public class AvgPool2D(
         name = name
     )
 
-    override fun build(tf: Ops, inputShape: Shape): Unit = Unit
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         var rows = inputShape.size(1)
         var cols = inputShape.size(2)
         rows = convOutputLength(

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool2D.kt
@@ -8,9 +8,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -43,26 +41,10 @@ public class AvgPool2D(
         name = name
     )
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        var rows = inputShape.size(1)
-        var cols = inputShape.size(2)
-        rows = convOutputLength(
-            rows, poolSize[1], padding,
-            strides[1]
-        )
-        cols = convOutputLength(
-            cols, poolSize[2], padding,
-            strides[2]
-        )
-
-        return Shape.make(inputShape.size(0), rows, cols, inputShape.size(3))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return tf.nn.avgPool(
             input,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool3D.kt
@@ -56,9 +56,7 @@ public class AvgPool3D(
         }
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Unit = Unit
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         val dim1 = convOutputLength(inputShape.size(1), poolSize[1], padding, strides[1])
         val dim2 = convOutputLength(inputShape.size(2), poolSize[2], padding, strides[2])
         val dim3 = convOutputLength(inputShape.size(3), poolSize[3], padding, strides[3])

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/AvgPool3D.kt
@@ -9,9 +9,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -56,19 +54,10 @@ public class AvgPool3D(
         }
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        val dim1 = convOutputLength(inputShape.size(1), poolSize[1], padding, strides[1])
-        val dim2 = convOutputLength(inputShape.size(2), poolSize[2], padding, strides[2])
-        val dim3 = convOutputLength(inputShape.size(3), poolSize[3], padding, strides[3])
-
-        return Shape.make(inputShape.size(0), dim1, dim2, dim3, inputShape.size(4))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return tf.nn.avgPool3d(
             input,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool1D.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.util.TF
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -24,15 +23,11 @@ import org.tensorflow.op.Ops
 public class GlobalAvgPool1D(
     name: String = ""
 ) : Layer(name) {
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(inputShape.size(0), inputShape.size(2))
-    }
 
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         val stepAxis = 1
         // TODO support for masking

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool1D.kt
@@ -24,9 +24,7 @@ import org.tensorflow.op.Ops
 public class GlobalAvgPool1D(
     name: String = ""
 ) : Layer(name) {
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(inputShape.size(0), inputShape.size(2))
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool2D.kt
@@ -28,9 +28,7 @@ import org.tensorflow.op.Ops
 public class GlobalAvgPool2D(
     name: String = ""
 ) : Layer(name) {
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(inputShape.size(0), inputShape.size(3)) //   if (this.dataFormat == 'channelsLast')
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool2D.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.util.TF
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -28,15 +27,10 @@ import org.tensorflow.op.Ops
 public class GlobalAvgPool2D(
     name: String = ""
 ) : Layer(name) {
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(inputShape.size(0), inputShape.size(3)) //   if (this.dataFormat == 'channelsLast')
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return TF.mean(tf, input, tf.constant(intArrayOf(1, 2)))
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool3D.kt
@@ -27,9 +27,7 @@ import org.tensorflow.op.Ops
 public class GlobalAvgPool3D(
     name: String = ""
 ) : Layer(name) {
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(inputShape.size(0), inputShape.size(4))
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool3D.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.util.TF
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -27,15 +26,10 @@ import org.tensorflow.op.Ops
 public class GlobalAvgPool3D(
     name: String = ""
 ) : Layer(name) {
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(inputShape.size(0), inputShape.size(4))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return TF.mean(tf, input, tf.constant(intArrayOf(1, 2, 3)))
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool1D.kt
@@ -24,9 +24,7 @@ public class GlobalMaxPool1D(
     override val hasActivation: Boolean
         get() = false
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(inputShape.size(0), inputShape.size(2))
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool1D.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -24,15 +23,10 @@ public class GlobalMaxPool1D(
     override val hasActivation: Boolean
         get() = false
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(inputShape.size(0), inputShape.size(2))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return tf.max(input, tf.constant(1))
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool2D.kt
@@ -24,9 +24,7 @@ public class GlobalMaxPool2D(
     override val hasActivation: Boolean
         get() = false
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(inputShape.size(0), inputShape.size(3))
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool2D.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -24,15 +23,10 @@ public class GlobalMaxPool2D(
     override val hasActivation: Boolean
         get() = false
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(inputShape.size(0), inputShape.size(3))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return tf.max(input, tf.constant(intArrayOf(1, 2)))
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool3D.kt
@@ -24,9 +24,7 @@ public class GlobalMaxPool3D(
     override val hasActivation: Boolean
         get() = false
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(inputShape.size(0), inputShape.size(4))
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalMaxPool3D.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -24,15 +23,10 @@ public class GlobalMaxPool3D(
     override val hasActivation: Boolean
         get() = false
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(inputShape.size(0), inputShape.size(4))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return tf.max(input, tf.constant(intArrayOf(1, 2, 3)))
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool1D.kt
@@ -56,9 +56,7 @@ public class MaxPool1D(
         }
     }
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         val steps = convOutputLength(inputShape.size(1), poolSize[1], padding, strides[1])
         return Shape.make(inputShape.size(0), steps, inputShape.size(2))
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool1D.kt
@@ -8,9 +8,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.core.Squeeze
 
@@ -56,16 +54,10 @@ public class MaxPool1D(
         }
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        val steps = convOutputLength(inputShape.size(1), poolSize[1], padding, strides[1])
-        return Shape.make(inputShape.size(0), steps, inputShape.size(2))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         /**
          * Since the low-level Java API does not provide a function for 1D max-pooling,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool2D.kt
@@ -42,9 +42,7 @@ public class MaxPool2D(
         name = name
     )
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         var rows = inputShape.size(1)
         var cols = inputShape.size(2)
         rows = convOutputLength(

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool2D.kt
@@ -7,9 +7,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -42,26 +40,10 @@ public class MaxPool2D(
         name = name
     )
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        var rows = inputShape.size(1)
-        var cols = inputShape.size(2)
-        rows = convOutputLength(
-            rows, poolSize[1], padding,
-            strides[1]
-        )
-        cols = convOutputLength(
-            cols, poolSize[2], padding,
-            strides[2]
-        )
-
-        return Shape.make(inputShape.size(0), rows, cols, inputShape.size(3))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         val paddingName = padding.paddingName
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool3D.kt
@@ -7,9 +7,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
-import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import java.util.*
 
@@ -43,23 +41,10 @@ public class MaxPool3D(
         name = name
     )
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        var lenDim1: Long = inputShape.size(1)
-        var lenDim2: Long = inputShape.size(2)
-        var lenDim3: Long = inputShape.size(3)
-
-        lenDim1 = convOutputLength(lenDim1, poolSize[1], padding, strides[1])
-        lenDim2 = convOutputLength(lenDim2, poolSize[2], padding, strides[2])
-        lenDim3 = convOutputLength(lenDim3, poolSize[3], padding, strides[3])
-
-        return Shape.make(inputShape.size(0), lenDim1, lenDim2, lenDim3, inputShape.size(4))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         val paddingName = padding.paddingName
         val tfPoolSize = Arrays.stream(poolSize).asLongStream().toArray()

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool3D.kt
@@ -43,9 +43,7 @@ public class MaxPool3D(
         name = name
     )
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         var lenDim1: Long = inputShape.size(1)
         var lenDim2: Long = inputShape.size(2)
         var lenDim3: Long = inputShape.size(3)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/regularization/Dropout.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/regularization/Dropout.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.regularization
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -34,15 +33,10 @@ public class Dropout(
     name: String = ""
 ) : Layer(name), NoGradients {
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return inputShape
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         /* if (isTraining) {
              val trainingFactor = tf.placeholderWithDefault(tf.constant(1.0f), Shape.scalar())

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/regularization/Dropout.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/regularization/Dropout.kt
@@ -34,10 +34,7 @@ public class Dropout(
     name: String = ""
 ) : Layer(name), NoGradients {
 
-    override fun build(tf: Ops, inputShape: Shape) {
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return inputShape
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractCropping.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractCropping.kt
@@ -23,8 +23,6 @@ public abstract class AbstractCropping(
     override val hasActivation: Boolean
         get() = false
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
     override fun forward(
         tf: Ops,
         input: Operand<Float>,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractCropping.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractCropping.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -23,7 +22,7 @@ public abstract class AbstractCropping(
     override val hasActivation: Boolean
         get() = false
 
-    override fun forward(
+    override fun build(
         tf: Ops,
         input: Operand<Float>,
         isTraining: Operand<Boolean>,
@@ -34,7 +33,7 @@ public abstract class AbstractCropping(
 
     /**
      * The actual implementation of cropping operation which each subclassed layer needs to
-     * implement. This method will then be called from [forward] method to crop the input tensor.
+     * implement. This method will then be called from [build] method to crop the input tensor.
      */
     protected abstract fun crop(tf: Ops, input: Operand<Float>): Operand<Float>
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractUpSampling.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractUpSampling.kt
@@ -27,8 +27,6 @@ public abstract class AbstractUpSampling(
     override val hasActivation: Boolean
         get() = false
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
     override fun forward(
         tf: Ops,
         input: Operand<Float>,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractUpSampling.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractUpSampling.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -27,18 +26,17 @@ public abstract class AbstractUpSampling(
     override val hasActivation: Boolean
         get() = false
 
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         return upSample(tf, input)
     }
 
     /**
      * The actual implementation of upsampling operation which each subclassed layer needs to
-     * implement. This method will then be called from [forward] method to upsample the input tensor.
+     * implement. This method will then be called from [build] method to upsample the input tensor.
      */
     protected abstract fun upSample(tf: Ops, input: Operand<Float>): Operand<Float>
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractZeroPadding.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/AbstractZeroPadding.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.tensorflow.Operand
+import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -17,21 +18,21 @@ public abstract class AbstractZeroPadding(
 ) : Layer(name) {
     override val hasActivation: Boolean get() = false
 
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
-        val paddingOperand = tf.constant(paddingArrayToTfFormat())
+        val inputShape = input.asOutput().shape()
+        val paddingOperand = tf.constant(paddingArrayToTfFormat(inputShape))
         val constantValue = tf.constant(0f)
         return tf.pad(input, paddingOperand, constantValue)
     }
 
     /**
      * This function helps in computing the padding operand i.e. normalizing the padding array
-     * into a tensorflow format. This method will then be called in [forward] method that will be
+     * into a tensorflow format. This method will then be called in [build] method that will be
      * further passed to tf.pad().
      */
-    protected abstract fun paddingArrayToTfFormat(): Array<IntArray>
+    protected abstract fun paddingArrayToTfFormat(inputShape: Shape): Array<IntArray>
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping1D.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -34,14 +33,6 @@ public class Cropping1D(
         require(cropping.size == 2) {
             "The cropping should be an array of size 2."
         }
-    }
-
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(
-            inputShape.size(0),
-            inputShape.size(1) - cropping[0] - cropping[1],
-            inputShape.size(2)
-        )
     }
 
     override fun crop(tf: Ops, input: Operand<Float>): Operand<Float> {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping1D.kt
@@ -36,7 +36,7 @@ public class Cropping1D(
         }
     }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(
             inputShape.size(0),
             inputShape.size(1) - cropping[0] - cropping[1],

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping2D.kt
@@ -37,7 +37,7 @@ public class Cropping2D(
         }
     }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(
             inputShape.size(0),
             inputShape.size(1) - cropping[0][0] - cropping[0][1],

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping2D.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -35,15 +34,6 @@ public class Cropping2D(
         require(cropping[0].size == 2 && cropping[1].size == 2) {
             "All elements of cropping should be arrays of size 2."
         }
-    }
-
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(
-            inputShape.size(0),
-            inputShape.size(1) - cropping[0][0] - cropping[0][1],
-            inputShape.size(2) - cropping[1][0] - cropping[1][1],
-            inputShape.size(3)
-        )
     }
 
     override fun crop(tf: Ops, input: Operand<Float>): Operand<Float> {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping3D.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -37,16 +36,6 @@ public class Cropping3D(
         require(cropping.all { it.size == 2 }) {
             "All elements of cropping should be arrays of size 2."
         }
-    }
-
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(
-            inputShape.size(0),
-            inputShape.size(1) - cropping[0][0] - cropping[0][1],
-            inputShape.size(2) - cropping[1][0] - cropping[1][1],
-            inputShape.size(3) - cropping[2][0] - cropping[2][1],
-            inputShape.size(4)
-        )
     }
 
     override fun crop(tf: Ops, input: Operand<Float>): Operand<Float> {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Cropping3D.kt
@@ -39,7 +39,7 @@ public class Cropping3D(
         }
     }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(
             inputShape.size(0),
             inputShape.size(1) - cropping[0][0] - cropping[0][1],

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Flatten.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Flatten.kt
@@ -22,15 +22,11 @@ import kotlin.math.abs
 public class Flatten(name: String = "") : Layer(name) {
     private lateinit var units: Constant<Int>
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         val tensorShape = TensorShape(inputShape)
         val amountOfNeuronsInFlattenLayer = (tensorShape.numElements() / abs(tensorShape.size(0))).toInt()
         units = tf.constant(intArrayOf(-1, amountOfNeuronsInFlattenLayer))
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
         // leaves unknown dimensions unknown
-        val tensorShape = TensorShape(inputShape)
         return Shape.make(tensorShape.head(), tensorShape.numElements())
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Flatten.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Flatten.kt
@@ -8,9 +8,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
-import org.tensorflow.op.core.Constant
 import kotlin.math.abs
 
 /**
@@ -20,22 +18,15 @@ import kotlin.math.abs
  * @constructor Creates [Flatten] object.
  */
 public class Flatten(name: String = "") : Layer(name) {
-    private lateinit var units: Constant<Int>
-
-    override fun build(tf: Ops, inputShape: Shape): Shape {
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
+    ): Operand<Float> {
+        val inputShape = input.asOutput().shape()
         val tensorShape = TensorShape(inputShape)
         val amountOfNeuronsInFlattenLayer = (tensorShape.numElements() / abs(tensorShape.size(0))).toInt()
-        units = tf.constant(intArrayOf(-1, amountOfNeuronsInFlattenLayer))
-        // leaves unknown dimensions unknown
-        return Shape.make(tensorShape.head(), tensorShape.numElements())
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
-    ): Operand<Float> {
+        val units = tf.constant(intArrayOf(-1, amountOfNeuronsInFlattenLayer))
         return tf.reshape(input, units)
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Permute.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Permute.kt
@@ -5,10 +5,7 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
-import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
-import org.jetbrains.kotlinx.dl.api.core.shape.toLongArray
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -32,20 +29,10 @@ public class Permute(
         }
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        val outputShape = inputShape.toLongArray()
-        dims.forEachIndexed { i, dim ->
-            val targetDim = inputShape.size(dim)
-            outputShape[i + 1] = targetDim
-        }
-        return shapeFromDims(*outputShape)
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         val permArray = intArrayOf(0) + dims
         val perm = tf.constant(permArray)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Permute.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Permute.kt
@@ -32,9 +32,7 @@ public class Permute(
         }
     }
 
-    override fun build(tf: Ops, inputShape: Shape) {}
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         val outputShape = inputShape.toLongArray()
         dims.forEachIndexed { i, dim ->
             val targetDim = inputShape.size(dim)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/RepeatVector.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/RepeatVector.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -32,18 +31,10 @@ public class RepeatVector(
         require(n >= 1) { "Number of repetitions (n) in RepeatVector should be positive but got $n" }
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        require(inputShape.numDimensions() == 2) {
-            "Input tensor must have 2 dimensions but got ${inputShape.numDimensions()}"
-        }
-        return Shape.make(inputShape.size(0), n.toLong(), inputShape.size(1))
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
     ): Operand<Float> {
         val x = tf.expandDims(input, tf.constant(1))
         val pattern = tf.stack(listOf(tf.constant(1), tf.constant(n), tf.constant(1)))

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/RepeatVector.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/RepeatVector.kt
@@ -32,9 +32,7 @@ public class RepeatVector(
         require(n >= 1) { "Number of repetitions (n) in RepeatVector should be positive but got $n" }
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Unit = Unit
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         require(inputShape.numDimensions() == 2) {
             "Input tensor must have 2 dimensions but got ${inputShape.numDimensions()}"
         }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Reshape.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Reshape.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.core.Constant
 
@@ -30,20 +29,14 @@ public class Reshape(
 ) : Layer(name) {
     private lateinit var units: Constant<Int>
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
+    override fun build(tf: Ops,
+                       input: Operand<Float>,
+                       isTraining: Operand<Boolean>,
+                       numberOfLosses: Operand<Float>?
+    ): Operand<Float> {
         units = tf.constant(IntArray(targetShape.size + 1) {
             if (it == 0) -1 else targetShape[it - 1]
         })
-        // leaves unknown dimensions unknown
-        return Shape.make(inputShape.size(0), *targetShape.map { it.toLong() }.toLongArray())
-    }
-
-    override fun forward(
-        tf: Ops,
-        input: Operand<Float>,
-        isTraining: Operand<Boolean>,
-        numberOfLosses: Operand<Float>?
-    ): Operand<Float> {
         return tf.reshape(input, units)
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Reshape.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Reshape.kt
@@ -30,15 +30,13 @@ public class Reshape(
 ) : Layer(name) {
     private lateinit var units: Constant<Int>
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         units = tf.constant(IntArray(targetShape.size + 1) {
             if (it == 0) -1 else targetShape[it - 1]
         })
+        // leaves unknown dimensions unknown
+        return Shape.make(inputShape.size(0), *targetShape.map { it.toLong() }.toLongArray())
     }
-
-    // leaves unknown dimensions unknown
-    override fun computeOutputShape(inputShape: Shape): Shape =
-        Shape.make(inputShape.size(0), *targetShape.map { it.toLong() }.toLongArray())
 
     override fun forward(
         tf: Ops,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling1D.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -34,14 +33,6 @@ public class UpSampling1D(
         require(size > 0) {
             "The upsampling size should be a positive integer."
         }
-    }
-
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(
-            inputShape.size(0),
-            inputShape.size(1) * size,
-            inputShape.size(2)
-        )
     }
 
     protected override fun upSample(tf: Ops, input: Operand<Float>): Operand<Float> {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling1D.kt
@@ -36,7 +36,7 @@ public class UpSampling1D(
         }
     }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(
             inputShape.size(0),
             inputShape.size(1) * size,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling2D.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.image.ResizeBilinear
 
@@ -47,15 +46,6 @@ public class UpSampling2D(
         require(interpolation == InterpolationMethod.NEAREST || interpolation == InterpolationMethod.BILINEAR) {
             "The interpolation method should be either of `InterpolationMethod.NEAREST` or `InterpolationMethod.BILINEAR`."
         }
-    }
-
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(
-            inputShape.size(0),
-            inputShape.size(1) * size[0],
-            inputShape.size(2) * size[1],
-            inputShape.size(3)
-        )
     }
 
     protected override fun upSample(tf: Ops, input: Operand<Float>): Operand<Float> {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling2D.kt
@@ -49,7 +49,7 @@ public class UpSampling2D(
         }
     }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(
             inputShape.size(0),
             inputShape.size(1) * size[0],

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling3D.kt
@@ -41,7 +41,7 @@ public class UpSampling3D(
         }
     }
 
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         return Shape.make(
             inputShape.size(0),
             inputShape.size(1) * size[0],

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling3D.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**
@@ -39,16 +38,6 @@ public class UpSampling3D(
         require(size.all { it > 0 }) {
             "All the upsampling size factors should be positive integers."
         }
-    }
-
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        return Shape.make(
-            inputShape.size(0),
-            inputShape.size(1) * size[0],
-            inputShape.size(2) * size[1],
-            inputShape.size(3) * size[2],
-            inputShape.size(4)
-        )
     }
 
     protected override fun upSample(tf: Ops, input: Operand<Float>): Operand<Float> {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding1D.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.tensorflow.Shape
-import org.tensorflow.op.Ops
 
 /**
  * Zero-padding layer for 1D input (e.g. audio).
@@ -17,7 +16,6 @@ import org.tensorflow.op.Ops
  */
 public class ZeroPadding1D : AbstractZeroPadding {
     public val padding: IntArray
-    private lateinit var inputShape: Shape
 
     /**
      * Constructs an instance of ZeroPadding1D layer
@@ -59,13 +57,7 @@ public class ZeroPadding1D : AbstractZeroPadding {
         this.padding = padding
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        this.inputShape = inputShape
-        val length = inputShape.size(1) + padding[0] + padding[1]
-        return Shape.make(inputShape.size(1), length, inputShape.size(2))
-    }
-
-    override fun paddingArrayToTfFormat(): Array<IntArray> {
+    override fun paddingArrayToTfFormat(inputShape: Shape): Array<IntArray> {
         return arrayOf(intArrayOf(0, 0), intArrayOf(padding[0], padding[1]), intArrayOf(0, 0))
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding1D.kt
@@ -59,11 +59,8 @@ public class ZeroPadding1D : AbstractZeroPadding {
         this.padding = padding
     }
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         this.inputShape = inputShape
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
         val length = inputShape.size(1) + padding[0] + padding[1]
         return Shape.make(inputShape.size(1), length, inputShape.size(2))
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding2D.kt
@@ -76,12 +76,10 @@ public class ZeroPadding2D : AbstractZeroPadding {
         this.dataFormat = dataFormat ?: CHANNELS_LAST
     }
 
-    override fun build(tf: Ops, inputShape: Shape) {
-        this.inputShape = inputShape
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         require(inputShape.numDimensions() == 4) { "input tensor must have 4 dimensions" }
+
+        this.inputShape = inputShape
 
         return if (dataFormat == CHANNELS_FIRST) {
             Shape.make(

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding2D.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 import org.jetbrains.kotlinx.dl.api.inference.keras.CHANNELS_FIRST
 import org.jetbrains.kotlinx.dl.api.inference.keras.CHANNELS_LAST
 import org.tensorflow.Shape
-import org.tensorflow.op.Ops
 
 /**
  * Zero-padding layer for 2D input (e.g. picture).
@@ -18,7 +17,6 @@ import org.tensorflow.op.Ops
 public class ZeroPadding2D : AbstractZeroPadding {
     public val padding: IntArray
     private val dataFormat: String
-    private lateinit var inputShape: Shape
 
     /**
      * Constructs an instance of ZeroPadding2D layer
@@ -76,29 +74,7 @@ public class ZeroPadding2D : AbstractZeroPadding {
         this.dataFormat = dataFormat ?: CHANNELS_LAST
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        require(inputShape.numDimensions() == 4) { "input tensor must have 4 dimensions" }
-
-        this.inputShape = inputShape
-
-        return if (dataFormat == CHANNELS_FIRST) {
-            Shape.make(
-                inputShape.size(0),
-                inputShape.size(1),
-                inputShape.size(2) + padding[0] + padding[1],
-                inputShape.size(3) + padding[2] + padding[3]
-            )
-        } else {
-            Shape.make(
-                inputShape.size(0),
-                inputShape.size(1) + padding[0] + padding[1],
-                inputShape.size(2) + padding[2] + padding[3],
-                inputShape.size(3)
-            )
-        }
-    }
-
-    override fun paddingArrayToTfFormat(): Array<IntArray> {
+    override fun paddingArrayToTfFormat(inputShape: Shape): Array<IntArray> {
         val paddingFirstDim: IntArray
         val paddingSecondDim: IntArray
 
@@ -117,10 +93,10 @@ public class ZeroPadding2D : AbstractZeroPadding {
             }
             else -> throw IllegalArgumentException("Invalid padding argument at layer $name.")
         }
-        return paddingArraysToInputShape(paddingFirstDim, paddingSecondDim)
+        return paddingArraysToInputShape(inputShape, paddingFirstDim, paddingSecondDim)
     }
 
-    private fun paddingArraysToInputShape(paddingFirstDim: IntArray, paddingSecondDim: IntArray): Array<IntArray> {
+    private fun paddingArraysToInputShape(inputShape: Shape, paddingFirstDim: IntArray, paddingSecondDim: IntArray): Array<IntArray> {
         return when (inputShape.numDimensions()) {
             4 -> {
                 if (dataFormat == CHANNELS_FIRST) {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding3D.kt
@@ -81,11 +81,8 @@ public class ZeroPadding3D : AbstractZeroPadding {
         this.padding = padding
     }
 
-    override fun build(tf: Ops, inputShape: Shape) {
+    override fun build(tf: Ops, inputShape: Shape): Shape {
         this.inputShape = inputShape
-    }
-
-    override fun computeOutputShape(inputShape: Shape): Shape {
         val dim1 = inputShape.size(1) + padding[0] + padding[1]
         val dim2 = inputShape.size(2) + padding[2] + padding[3]
         val dim3 = inputShape.size(3) + padding[4] + padding[5]

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding3D.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.tensorflow.Shape
-import org.tensorflow.op.Ops
 
 /**
  * Zero-padding layer for 3D input (e.g. video).
@@ -17,7 +16,6 @@ import org.tensorflow.op.Ops
  */
 public class ZeroPadding3D : AbstractZeroPadding {
     public val padding: IntArray
-    private lateinit var inputShape: Shape
 
     /**
      * Constructs an instance of ZeroPadding3D layer
@@ -81,15 +79,7 @@ public class ZeroPadding3D : AbstractZeroPadding {
         this.padding = padding
     }
 
-    override fun build(tf: Ops, inputShape: Shape): Shape {
-        this.inputShape = inputShape
-        val dim1 = inputShape.size(1) + padding[0] + padding[1]
-        val dim2 = inputShape.size(2) + padding[2] + padding[3]
-        val dim3 = inputShape.size(3) + padding[4] + padding[5]
-        return Shape.make(inputShape.size(0), dim1, dim2, dim3, inputShape.size(4))
-    }
-
-    override fun paddingArrayToTfFormat(): Array<IntArray> {
+    override fun paddingArrayToTfFormat(inputShape: Shape): Array<IntArray> {
         val paddingFirstDim: IntArray
         val paddingSecondDim: IntArray
         val paddingThirdDim: IntArray
@@ -112,10 +102,11 @@ public class ZeroPadding3D : AbstractZeroPadding {
             }
             else -> throw IllegalArgumentException("Invalid padding argument at layer $name.")
         }
-        return paddingArraysToInputShape(paddingFirstDim, paddingSecondDim, paddingThirdDim)
+        return paddingArraysToInputShape(inputShape, paddingFirstDim, paddingSecondDim, paddingThirdDim)
     }
 
     private fun paddingArraysToInputShape(
+        inputShape: Shape,
         paddingFirstDim: IntArray,
         paddingSecondDim: IntArray,
         paddingThirdDim: IntArray
@@ -124,7 +115,7 @@ public class ZeroPadding3D : AbstractZeroPadding {
             5 -> arrayOf(intArrayOf(0, 0), paddingFirstDim, paddingSecondDim, paddingThirdDim, intArrayOf(0, 0))
             4 -> arrayOf(paddingFirstDim, paddingSecondDim, paddingThirdDim, intArrayOf(0, 0))
             3 -> arrayOf(paddingFirstDim, paddingSecondDim, paddingThirdDim)
-            else -> throw IllegalArgumentException("Invalid input shape $inputShape.")
+            else -> throw IllegalArgumentException("Invalid input shape ${inputShape}.")
         }
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/shape/ShapeFunctions.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/shape/ShapeFunctions.kt
@@ -140,3 +140,7 @@ private fun getShapeOfArray(data: Array<*>): Shape {
  * If the most inner array does not have any elements its size is missed in result
  */
 internal val Array<*>.shape: Shape get() = getShapeOfArray(this)
+
+internal fun Shape.copy(): Shape {
+    return Shape.make(size(0), *tail(this))
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ActivationLayerTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ActivationLayerTest.kt
@@ -28,12 +28,10 @@ open class ActivationLayerTest {
         EagerSession.create().use {
             val tf = Ops.create(it)
             val inputOp = tf.constant(input)
-            val inputShape = inputOp.asOutput().shape()
-            layer.build(tf, inputShape)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
 
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses)
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses)
             val actualShape = shapeFromDims(*output.asOutput().tensor().shape())
             assertEquals(expectedShape, actualShape)
 
@@ -59,15 +57,13 @@ open class ActivationLayerTest {
         expected: FloatArray
     ) {
         val inputSize = input.size
-        val inputShape = Shape.make(inputSize.toLong())
 
         EagerSession.create().use {
             val tf = Ops.create(it)
             val inputOp = tf.constant(input)
-            layer.build(tf, inputShape)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput().tensor()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput().tensor()
 
             val expectedShape = Shape.make(
                 inputSize.toLong()

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/AvgPool1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/AvgPool1DTest.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlinx.dl.api.core.shape.toIntArray
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.tensorflow.EagerSession
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 private const val EPS: Float = 1e-6f
@@ -47,13 +46,10 @@ internal class AvgPool1DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            val inputShape = Shape.make(input.size.toLong(), input[0].size.toLong(), input[0][0].size.toLong())
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, 2, input[0][0].size)
@@ -111,13 +107,10 @@ internal class AvgPool1DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            val inputShape = Shape.make(input.size.toLong(), input[0].size.toLong(), input[0][0].size.toLong())
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, input[0].size, input[0][0].size)
@@ -171,13 +164,10 @@ internal class AvgPool1DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            val inputShape = Shape.make(input.size.toLong(), input[0].size.toLong(), input[0][0].size.toLong())
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, 2, input[0][0].size)

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/AvgPool3DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/AvgPool3DTest.kt
@@ -70,12 +70,10 @@ internal class AvgPool3DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, 1, 1, 2, input[0][0][0][0].size)
@@ -143,12 +141,10 @@ internal class AvgPool3DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = inputShape.toIntArray()
@@ -200,12 +196,10 @@ internal class AvgPool3DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, 1, 1, 2, input[0][0][0][0].size)

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ConvLayerTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ConvLayerTest.kt
@@ -29,8 +29,7 @@ open class ConvLayerTest {
                 val isTraining = tf.constant(true)
                 val numberOfLosses = tf.constant(1.0f)
 
-                layer.build(tf, input.shape)
-                layer.setOutputShape(layer.computeOutputShape(input.shape))
+                layer.setOutputShape(layer.build(tf, input.shape))
                 val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
                 (layer as? ParametrizedLayer)?.initialize(session)
                 session.runner().fetch(output).run().first().use { outputTensor ->

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ConvLayerTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ConvLayerTest.kt
@@ -30,7 +30,7 @@ open class ConvLayerTest {
                 val numberOfLosses = tf.constant(1.0f)
 
                 layer.build(tf, input.shape)
-                layer.computeOutputShape(input.shape)
+                layer.setOutputShape(layer.computeOutputShape(input.shape))
                 val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
                 (layer as? ParametrizedLayer)?.initialize(session)
                 session.runner().fetch(output).run().first().use { outputTensor ->

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ConvLayerTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ConvLayerTest.kt
@@ -29,8 +29,8 @@ open class ConvLayerTest {
                 val isTraining = tf.constant(true)
                 val numberOfLosses = tf.constant(1.0f)
 
-                layer.setOutputShape(layer.build(tf, input.shape))
-                val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+                val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
+                layer.setOutputShape(output.shape())
                 (layer as? ParametrizedLayer)?.initialize(session)
                 session.runner().fetch(output).run().first().use { outputTensor ->
                     val outputShape = outputTensor.shape()

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Cropping1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Cropping1DTest.kt
@@ -41,6 +41,6 @@ internal class Cropping1DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[1] - 1 - 2, inputShape[2])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Cropping2DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Cropping2DTest.kt
@@ -44,6 +44,6 @@ internal class Cropping2DTest : LayerTest() {
         val expectedShape = longArrayOf(
             inputShape[0], inputShape[1] - 1, inputShape[2] - 1 - 2, inputShape[3]
         )
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Cropping3DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Cropping3DTest.kt
@@ -65,6 +65,6 @@ internal class Cropping3DTest : LayerTest() {
         val expectedShape = longArrayOf(
             inputShape[0], inputShape[1] - 1, inputShape[2] - 1, inputShape[3] - 1 - 1, inputShape[4]
         )
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalAvgPool1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalAvgPool1DTest.kt
@@ -36,6 +36,6 @@ internal class GlobalAvgPool1DTest : LayerTest() {
         assertLayerOutputIsCorrect(layer, input, expected)
         assertLayerOutputIsCorrect(layer, input, expected, RunMode.GRAPH)
         val expectedShape = longArrayOf(inputShape[0], inputShape[2])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalAvgPool2DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalAvgPool2DTest.kt
@@ -49,6 +49,6 @@ internal class GlobalAvgPool2DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[3])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalAvgPool3DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalAvgPool3DTest.kt
@@ -49,6 +49,6 @@ internal class GlobalAvgPool3DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[4])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalMaxPool1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalMaxPool1DTest.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlinx.dl.api.core.shape.toIntArray
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.tensorflow.EagerSession
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 internal class GlobalMaxPool1DTest {
@@ -34,13 +33,10 @@ internal class GlobalMaxPool1DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            val inputShape = Shape.make(input.size.toLong(), input[0].size.toLong(), input[0][0].size.toLong())
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, input[0][0].size)

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalMaxPool2DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalMaxPool2DTest.kt
@@ -49,6 +49,6 @@ internal class GlobalMaxPool2DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[3])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalMaxPool3DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/GlobalMaxPool3DTest.kt
@@ -54,6 +54,6 @@ class GlobalMaxPool3DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[4])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/LayerTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/LayerTest.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer
 
 import org.jetbrains.kotlinx.dl.api.core.shape.flattenFloats
 import org.jetbrains.kotlinx.dl.api.core.shape.shape
-import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
 import org.jetbrains.kotlinx.dl.api.core.shape.toLongArray
 import org.jetbrains.kotlinx.dl.api.extension.convertTensorToFlattenFloatArray
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -30,7 +29,7 @@ open class LayerTest {
         input: Array<*>,
     ): Output<*> {
         val inputShape = input.shape
-        layer.build(tf, inputShape)
+        layer.setOutputShape(layer.build(tf, inputShape))
         val inputOp = getInputOp(tf, input)
         val isTraining = tf.constant(true)
         val numberOfLosses = tf.constant(1.0f)
@@ -95,21 +94,10 @@ open class LayerTest {
 
     /**
      * Checks the computed output shape of layer is equal to the expected output shape.
-     *
-     * Essentially, this method invokes the `computeOutputShape` of a layer instance ([layer])
-     * given an input shape array ([inputShapeArray]) and verifies its output is equal to the
-     * expected output shape ([expectedOutputShape]).
      */
-    protected fun assertLayerComputedOutputShape(
-        layer: Layer,
-        inputShapeArray: LongArray,
-        expectedOutputShape: LongArray,
-    ) {
-        val inputShape = shapeFromDims(*inputShapeArray)
-        val outputShape = layer.computeOutputShape(inputShape).toLongArray()
+    protected fun assertLayerComputedOutputShape(layer: Layer, expectedOutputShape: LongArray) {
         assertArrayEquals(
-            expectedOutputShape,
-            outputShape,
+            expectedOutputShape, layer.outputShape.dims(),
             "Computed output shape differs from expected output shape!",
         )
     }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/LayerTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/LayerTest.kt
@@ -28,12 +28,11 @@ open class LayerTest {
         layer: Layer,
         input: Array<*>,
     ): Output<*> {
-        val inputShape = input.shape
-        layer.setOutputShape(layer.build(tf, inputShape))
         val inputOp = getInputOp(tf, input)
         val isTraining = tf.constant(true)
         val numberOfLosses = tf.constant(1.0f)
-        val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+        val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
+        layer.setOutputShape(output.shape())
         return output
     }
 

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/MaxPool1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/MaxPool1DTest.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlinx.dl.api.core.shape.toIntArray
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.tensorflow.EagerSession
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 internal class MaxPool1DTest {
@@ -45,13 +44,10 @@ internal class MaxPool1DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            val inputShape = Shape.make(input.size.toLong(), input[0].size.toLong(), input[0][0].size.toLong())
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, 2, input[0][0].size)
@@ -108,13 +104,10 @@ internal class MaxPool1DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            val inputShape = Shape.make(input.size.toLong(), input[0].size.toLong(), input[0][0].size.toLong())
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, input[0].size, input[0][0].size)
@@ -167,13 +160,10 @@ internal class MaxPool1DTest {
 
         EagerSession.create().use {
             val tf = Ops.create()
-            val inputShape = Shape.make(input.size.toLong(), input[0].size.toLong(), input[0][0].size.toLong())
-            layer.build(tf, inputShape)
-
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+            val output = layer.build(tf, inputOp, isTraining, numberOfLosses).asOutput()
 
             // Check output shape is correct.
             val expectedShape = intArrayOf(input.size, 2, input[0][0].size)

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/MaxPool3DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/MaxPool3DTest.kt
@@ -76,11 +76,10 @@ internal class MaxPool3DTest {
         )
         EagerSession.create().use {
             val tf = Ops.create()
-            layer.build(tf, inputShape)
             val inputOp = tf.constant(input)
             val isTraining = tf.constant(true)
             val numOfLosses = tf.constant(1.0f)
-            val output = layer.forward(tf, inputOp, isTraining, numOfLosses).asOutput().tensor()
+            val output = layer.build(tf, inputOp, isTraining, numOfLosses).asOutput().tensor()
 
             val expectedShape = Shape.make(
                 expected.size.toLong(),

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/PReLUTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/PReLUTest.kt
@@ -35,7 +35,7 @@ class PReLUTest : LayerTest() {
 
         assertLayerOutputIsCorrect(layer, input, expected, RunMode.GRAPH)
         val expectedShape = inputShape
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 
     @Test
@@ -90,6 +90,6 @@ class PReLUTest : LayerTest() {
 
         assertLayerOutputIsCorrect(layer, input, expected, RunMode.GRAPH)
         val expectedShape = inputShape
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/PermuteTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/PermuteTest.kt
@@ -32,6 +32,6 @@ internal class PermuteTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[2], inputShape[1])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/RepeatVectorLayerTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/RepeatVectorLayerTest.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlinx.dl.api.core.shape.toIntArray
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.tensorflow.Output
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 internal class RepeatVectorLayerTest {
@@ -46,10 +45,9 @@ internal class RepeatVectorLayerTest {
 
     // TODO: generalise this for Layer, see https://github.com/JetBrains/KotlinDL/issues/145
     private operator fun RepeatVector.invoke(input: Array<FloatArray>): Output<Float> = Ops.create().let { tf ->
-        build(tf, Shape.make(10, 10))
         val inputOp = tf.constant(input)
         val isTraining = tf.constant(true)
         val numberOfLosses = tf.constant(1.0f)
-        forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
+        build(tf, inputOp, isTraining, numberOfLosses).asOutput()
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/UpSampling1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/UpSampling1DTest.kt
@@ -36,7 +36,7 @@ internal class UpSampling1DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[1] * 2, inputShape[2])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 
     @Test
@@ -57,6 +57,6 @@ internal class UpSampling1DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[1] * 3, inputShape[2])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/UpSampling2DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/UpSampling2DTest.kt
@@ -70,7 +70,7 @@ internal class UpSampling2DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[1] * 2, inputShape[2] * 2, inputShape[3])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 
     @Test
@@ -114,7 +114,7 @@ internal class UpSampling2DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[1] * 2, inputShape[2] * 2, inputShape[3])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 
     @Test
@@ -146,6 +146,6 @@ internal class UpSampling2DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[0], inputShape[1] * 2, inputShape[2], inputShape[3])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/UpSampling3DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/UpSampling3DTest.kt
@@ -109,7 +109,7 @@ internal class UpSampling3DTest : LayerTest() {
         val expectedShape = longArrayOf(
             inputShape[0], inputShape[1] * 2, inputShape[2] * 2, inputShape[3] * 2, inputShape[4]
         )
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 
     @Test
@@ -145,6 +145,6 @@ internal class UpSampling3DTest : LayerTest() {
         val expectedShape = longArrayOf(
             inputShape[0], inputShape[1], inputShape[2] * 2, inputShape[3], inputShape[4]
         )
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ZeroPadding1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ZeroPadding1DTest.kt
@@ -36,7 +36,7 @@ internal class ZeroPadding1DTest : LayerTest() {
             )
         )
         assertLayerOutputIsCorrect(layer, input, expected)
-        val expectedShape = longArrayOf(inputShape[1], inputShape[1] + 4, inputShape[2])
+        val expectedShape = longArrayOf(inputShape[0], inputShape[1] + 4, inputShape[2])
         assertLayerComputedOutputShape(layer, expectedShape)
     }
 
@@ -57,7 +57,7 @@ internal class ZeroPadding1DTest : LayerTest() {
             )
         )
         assertLayerOutputIsCorrect(layer, input, expected)
-        val expectedShape = longArrayOf(inputShape[1], inputShape[1] + 6, inputShape[2])
+        val expectedShape = longArrayOf(inputShape[0], inputShape[1] + 6, inputShape[2])
         assertLayerComputedOutputShape(layer, expectedShape)
     }
 
@@ -77,7 +77,7 @@ internal class ZeroPadding1DTest : LayerTest() {
             )
         )
         assertLayerOutputIsCorrect(layer, input, expected)
-        val expectedShape = longArrayOf(inputShape[1], inputShape[1] + 5, inputShape[2])
+        val expectedShape = longArrayOf(inputShape[0], inputShape[1] + 5, inputShape[2])
         assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ZeroPadding1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ZeroPadding1DTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -37,7 +37,7 @@ internal class ZeroPadding1DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[1], inputShape[1] + 4, inputShape[2])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 
     @Test
@@ -58,7 +58,7 @@ internal class ZeroPadding1DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[1], inputShape[1] + 6, inputShape[2])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 
     @Test
@@ -78,6 +78,6 @@ internal class ZeroPadding1DTest : LayerTest() {
         )
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape = longArrayOf(inputShape[1], inputShape[1] + 5, inputShape[2])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ZeroPadding2DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ZeroPadding2DTest.kt
@@ -24,8 +24,6 @@ internal class ZeroPadding2DTest {
     fun oneArgumentChannelsLast() {
         val padding = 1
         val inputDimensionsArray = intArrayOf(BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
-        val inputShape =
-            Shape.make(BATCH_SIZE.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong(), NUM_CHANNELS.toLong())
         val expectedOutputSize = IMAGE_SIZE + 2 * padding
 
         EagerSession.create().use {
@@ -33,10 +31,9 @@ internal class ZeroPadding2DTest {
             val paddingLayer = ZeroPadding2D(padding, dataFormat = CHANNELS_LAST)
             val inputDimensions = tf.constant(inputDimensionsArray)
             val input = Ones().initialize(1, 1, tf, inputDimensions, "test_input")
-            paddingLayer.build(tf, inputShape)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = paddingLayer.forward(tf, input, isTraining, numberOfLosses).asOutput().tensor()
+            val output = paddingLayer.build(tf, input, isTraining, numberOfLosses).asOutput().tensor()
 
             val expectedShape = Shape.make(
                 BATCH_SIZE.toLong(),
@@ -80,8 +77,6 @@ internal class ZeroPadding2DTest {
         val paddingWidth = 2
         val paddingArray = paddingHeight to paddingWidth
         val inputDimensionsArray = intArrayOf(BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
-        val inputShape =
-            Shape.make(BATCH_SIZE.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong(), NUM_CHANNELS.toLong())
         val expectedOutputHeight = IMAGE_SIZE + paddingHeight * 2
         val expectedOutputWidth = IMAGE_SIZE + paddingWidth * 2
 
@@ -90,10 +85,9 @@ internal class ZeroPadding2DTest {
             val paddingLayer = ZeroPadding2D(paddingArray, dataFormat = CHANNELS_LAST)
             val inputDimensions = tf.constant(inputDimensionsArray)
             val input = Ones().initialize(1, 1, tf, inputDimensions, "test_input")
-            paddingLayer.build(tf, inputShape)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = paddingLayer.forward(tf, input, isTraining, numberOfLosses).asOutput().tensor()
+            val output = paddingLayer.build(tf, input, isTraining, numberOfLosses).asOutput().tensor()
 
             val expectedShape = Shape.make(
                 BATCH_SIZE.toLong(),
@@ -139,8 +133,6 @@ internal class ZeroPadding2DTest {
         val paddingRight = 4
         val paddingArray = intArrayOf(paddingTop, paddingBottom, paddingLeft, paddingRight)
         val inputDimensionsArray = intArrayOf(BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
-        val inputShape =
-            Shape.make(BATCH_SIZE.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong(), NUM_CHANNELS.toLong())
         val expectedOutputHeight = IMAGE_SIZE + paddingTop + paddingBottom
         val expectedOutputWidth = IMAGE_SIZE + paddingLeft + paddingRight
 
@@ -149,10 +141,9 @@ internal class ZeroPadding2DTest {
             val paddingLayer = ZeroPadding2D(paddingArray, dataFormat = CHANNELS_LAST)
             val inputDimensions = tf.constant(inputDimensionsArray)
             val input = Ones().initialize(1, 1, tf, inputDimensions, "test_input")
-            paddingLayer.build(tf, inputShape)
             val isTraining = tf.constant(true)
             val numberOfLosses = tf.constant(1.0f)
-            val output = paddingLayer.forward(tf, input, isTraining, numberOfLosses).asOutput().tensor()
+            val output = paddingLayer.build(tf, input, isTraining, numberOfLosses).asOutput().tensor()
 
             val expectedShape = Shape.make(
                 BATCH_SIZE.toLong(),

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ZeroPadding3DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ZeroPadding3DTest.kt
@@ -84,6 +84,6 @@ internal class ZeroPadding3DTest : LayerTest() {
         assertLayerOutputIsCorrect(layer, input, expected)
         val expectedShape =
             longArrayOf(inputShape[0], inputShape[1] + 2, inputShape[2] + 2, inputShape[3] + 2, inputShape[4])
-        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+        assertLayerComputedOutputShape(layer, expectedShape)
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ReshapeTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ReshapeTest.kt
@@ -59,37 +59,4 @@ internal class ReshapeTest : LayerTest() {
         assertLayerOutputIsCorrect(layer, input, expected)
         assertLayerOutputIsCorrect(layer, input, expected, RunMode.GRAPH)
     }
-
-    @Test
-    fun computeOutputShape() {
-        assertLayerComputedOutputShape(
-            layer = Reshape(targetShape = listOf(1, 2, 3)),
-            inputShapeArray = longArrayOf(100, 3, 2, 1),
-            expectedOutputShape = longArrayOf(100, 1, 2, 3)
-        )
-
-        assertLayerComputedOutputShape(
-            layer = Reshape(targetShape = listOf(1, 2, 3)),
-            inputShapeArray = longArrayOf(-1, 3, 2, 1),
-            expectedOutputShape = longArrayOf(-1, 1, 2, 3)
-        )
-
-        assertLayerComputedOutputShape(
-            layer = Reshape(targetShape = listOf(6)),
-            inputShapeArray = longArrayOf(100, 3, 2, 1),
-            expectedOutputShape = longArrayOf(100, 6)
-        )
-
-        assertLayerComputedOutputShape(
-            layer = Reshape(targetShape = listOf(4, 5)),
-            inputShapeArray = longArrayOf(100, 20),
-            expectedOutputShape = longArrayOf(100, 4, 5)
-        )
-
-        assertLayerComputedOutputShape(
-            layer = Reshape(targetShape = listOf(4, 5, 6, 7, 8, 9, 10)),
-            inputShapeArray = longArrayOf(100, 4 * 5 * 6, 7 * 10, 8 * 9),
-            expectedOutputShape = longArrayOf(100, 4, 5, 6, 7, 8, 9, 10)
-        )
-    }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/models/SequentialCompilationTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/models/SequentialCompilationTest.kt
@@ -662,18 +662,17 @@ internal class SequentialModelTest {
         )
 
         vgg11.use {
-            val exception = assertThrows(IllegalStateException::class.java) {
-                it.compile(
-                    optimizer = Adam(),
-                    loss = Losses.SOFT_MAX_CROSS_ENTROPY_WITH_LOGITS,
-                    metric = Metrics.ACCURACY
-                )
+            assertThrows(IllegalArgumentException::class.java) {
+                try {
+                    it.compile(
+                        optimizer = Adam(),
+                        loss = Losses.SOFT_MAX_CROSS_ENTROPY_WITH_LOGITS,
+                        metric = Metrics.ACCURACY
+                    )
+                } catch (e : Throwable) {
+                    throw e
+                }
             }
-            assertEquals(
-                "The last dimensions (except first = -1) of shape of layer maxpool2d_14 contains zero or negative dimension values: [None, 0, 0, 128].\n" +
-                        "Analyze your model architecture and layer output shapes carefully to discover a problem.",
-                exception.message
-            )
         }
     }
 


### PR DESCRIPTION
This pull request attempts to simplify Layer building api by doing the following:

1. Unify functional and sequential functions signatures.
2. Remove separate output shape computation (btw, it was computed incorrectly in `ZeroPadding1D` and `Concatenate` layers).
3. Combine `Layer#build` and `Layer#forward` functions.
4. Combine `GraphTrainableModel#build` and `GraphTrainableModel#forward` functions.

This change was proposed as [a part of Layer api simplification](https://github.com/Kotlin/kotlindl/issues/233#:~:text=Combine%20computeOutputShape%2C%20build%20and%20forward). Apart from the benefits described in linked proposal, having a single `build` method will make it easier to split `Layer` into an immutable `Layer` containing variables and layer output and a reusable `LayerBuilder` for building the `Layer`.
Possible downsides so far consists of one thing: the api no longer will mimic Keras api and it would be more difficult for contributors to borrow its code to implement new layers.