### PR TITLE
Simplify onnx model api

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/ModelType.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/ModelType.kt
@@ -60,8 +60,4 @@ public interface ModelType<T : InferenceModel, U : InferenceModel> {
     public fun model(modelHub: ModelHub): T {
         return modelHub.loadModel(this)
     }
-
-    public fun preInit(): InferenceModel {
-        TODO()
-    }
 }

--- a/examples/src/test/kotlin/examples/onnx/ExecutionProvidersTestSuite.kt
+++ b/examples/src/test/kotlin/examples/onnx/ExecutionProvidersTestSuite.kt
@@ -81,7 +81,7 @@ class ExecutionProvidersTestSuite {
 
         model.use {
             assertDoesNotThrow {
-                model.reinitializeWith(CPU(), CPU(), CPU())
+                model.initializeWith(CPU(), CPU(), CPU())
             }
         }
     }
@@ -93,7 +93,7 @@ class ExecutionProvidersTestSuite {
 
         model.use {
             assertThrows<IllegalArgumentException> {
-                model.reinitializeWith(CPU(), CPU(false))
+                model.initializeWith(CPU(), CPU(false))
             }
         }
     }

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/loaders/ONNXModelHub.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/loaders/ONNXModelHub.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlinx.dl.api.inference.keras.loaders.ModelHub
 import org.jetbrains.kotlinx.dl.api.inference.keras.loaders.ModelType
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxModelType
 import org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders.ExecutionProvider
 import org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders.ExecutionProvider.CPU
 import java.io.File
@@ -55,7 +56,7 @@ public class ONNXModelHub(cacheDirectory: File) :
         modelType: ModelType<T, U>,
         loadingMode: LoadingMode
     ): T {
-        return loadModel(modelType, CPU(), loadingMode = LoadingMode.SKIP_LOADING_IF_EXISTS)
+        return loadModel(modelType as OnnxModelType<T, U>, CPU(), loadingMode = LoadingMode.SKIP_LOADING_IF_EXISTS)
     }
 
     private fun getONNXModelFile(modelFile: String, loadingMode: LoadingMode): File {
@@ -77,7 +78,7 @@ public class ONNXModelHub(cacheDirectory: File) :
 
     @Suppress("UNCHECKED_CAST")
     public fun <T : InferenceModel, U : InferenceModel> loadModel(
-        modelType: ModelType<T, U>,
+        modelType: OnnxModelType<T, U>,
         vararg executionProviders: ExecutionProvider,
         loadingMode: LoadingMode = LoadingMode.SKIP_LOADING_IF_EXISTS,
     ): T {
@@ -90,7 +91,7 @@ public class ONNXModelHub(cacheDirectory: File) :
         val inferenceModel = modelType.preInit()
 
         return OnnxInferenceModel.initializeONNXModel(
-            inferenceModel as OnnxInferenceModel,
+            inferenceModel,
             getONNXModelFile(modelFile, loadingMode).absolutePath,
             *executionProviders
         ) as T

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/loaders/ONNXModelHub.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/loaders/ONNXModelHub.kt
@@ -89,11 +89,8 @@ public class ONNXModelHub(cacheDirectory: File) :
         }
 
         val inferenceModel = modelType.createModel(getONNXModelFile(modelFile, loadingMode).absolutePath)
-
-        return OnnxInferenceModel.initializeONNXModel(
-            inferenceModel,
-            *executionProviders
-        ) as T
+        inferenceModel.initializeWith(*executionProviders)
+        return inferenceModel as T
     }
 }
 

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/loaders/ONNXModelHub.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/loaders/ONNXModelHub.kt
@@ -88,7 +88,7 @@ public class ONNXModelHub(cacheDirectory: File) :
             S3_FOLDER_SEPARATOR + modelType.modelRelativePath + MODEL_FILE_EXTENSION
         }
 
-        val inferenceModel = modelType.preInit()
+        val inferenceModel = modelType.createModel()
 
         return OnnxInferenceModel.initializeONNXModel(
             inferenceModel,

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/loaders/ONNXModelHub.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/loaders/ONNXModelHub.kt
@@ -88,11 +88,10 @@ public class ONNXModelHub(cacheDirectory: File) :
             S3_FOLDER_SEPARATOR + modelType.modelRelativePath + MODEL_FILE_EXTENSION
         }
 
-        val inferenceModel = modelType.createModel()
+        val inferenceModel = modelType.createModel(getONNXModelFile(modelFile, loadingMode).absolutePath)
 
         return OnnxInferenceModel.initializeONNXModel(
             inferenceModel,
-            getONNXModelFile(modelFile, loadingMode).absolutePath,
             *executionProviders
         ) as T
     }

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
@@ -35,7 +35,7 @@ public object ONNXModels {
             return ImageRecognitionModel(modelHub.loadModel(this), this)
         }
 
-        override fun preInit(): OnnxInferenceModel {
+        override fun createModel(): OnnxInferenceModel {
             return OnnxInferenceModel()
         }
 
@@ -659,7 +659,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as SSDObjectDetectionModel
             }
 
-            override fun preInit(): SSDObjectDetectionModel {
+            override fun createModel(): SSDObjectDetectionModel {
                 return SSDObjectDetectionModel()
             }
         }
@@ -699,7 +699,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as SSDMobileNetV1ObjectDetectionModel
             }
 
-            override fun preInit(): SSDMobileNetV1ObjectDetectionModel {
+            override fun createModel(): SSDMobileNetV1ObjectDetectionModel {
                 val model = SSDMobileNetV1ObjectDetectionModel()
                 model.inputShape = longArrayOf(1L, 1000L, 1000L, 3L)
                 return model
@@ -737,7 +737,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun preInit(): EfficientDetObjectDetectionModel {
+            override fun createModel(): EfficientDetObjectDetectionModel {
                 val model = EfficientDetObjectDetectionModel()
                 model.inputShape = longArrayOf(1L, 512L, 512L, 3L)
                 return model
@@ -774,7 +774,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun preInit(): EfficientDetObjectDetectionModel {
+            override fun createModel(): EfficientDetObjectDetectionModel {
                 val model = EfficientDetObjectDetectionModel()
                 model.inputShape = longArrayOf(1L, 640L, 640L, 3L)
                 return model
@@ -811,7 +811,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun preInit(): EfficientDetObjectDetectionModel {
+            override fun createModel(): EfficientDetObjectDetectionModel {
                 val model = EfficientDetObjectDetectionModel()
                 model.inputShape = longArrayOf(1L, 768L, 768L, 3L)
                 return model
@@ -848,7 +848,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun preInit(): EfficientDetObjectDetectionModel {
+            override fun createModel(): EfficientDetObjectDetectionModel {
                 val model = EfficientDetObjectDetectionModel()
                 model.inputShape = longArrayOf(1L, 896L, 896L, 3L)
                 return model
@@ -885,7 +885,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun preInit(): EfficientDetObjectDetectionModel {
+            override fun createModel(): EfficientDetObjectDetectionModel {
                 val model = EfficientDetObjectDetectionModel()
                 model.inputShape = longArrayOf(1L, 1024L, 1024L, 3L)
                 return model
@@ -922,7 +922,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun preInit(): EfficientDetObjectDetectionModel {
+            override fun createModel(): EfficientDetObjectDetectionModel {
                 val model = EfficientDetObjectDetectionModel()
                 model.inputShape = longArrayOf(1L, 1280L, 1280L, 3L)
                 return model
@@ -959,7 +959,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun preInit(): EfficientDetObjectDetectionModel {
+            override fun createModel(): EfficientDetObjectDetectionModel {
                 val model = EfficientDetObjectDetectionModel()
                 model.inputShape = longArrayOf(1L, 1280L, 1280L, 3L)
                 return model
@@ -994,7 +994,7 @@ public object ONNXModels {
                 return Fan2D106FaceAlignmentModel(modelHub.loadModel(this))
             }
 
-            override fun preInit(): OnnxInferenceModel {
+            override fun createModel(): OnnxInferenceModel {
                 return OnnxInferenceModel()
             }
         }
@@ -1037,7 +1037,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as SinglePoseDetectionModel
             }
 
-            override fun preInit(): SinglePoseDetectionModel {
+            override fun createModel(): SinglePoseDetectionModel {
                 return SinglePoseDetectionModel()
             }
         }
@@ -1076,7 +1076,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as MultiPoseDetectionModel
             }
 
-            override fun preInit(): MultiPoseDetectionModel {
+            override fun createModel(): MultiPoseDetectionModel {
                 val model = MultiPoseDetectionModel()
                 model.inputShape = longArrayOf(1L, 256L, 256L, 3L)
                 return model
@@ -1113,7 +1113,7 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as SinglePoseDetectionModel
             }
 
-            override fun preInit(): SinglePoseDetectionModel {
+            override fun createModel(): SinglePoseDetectionModel {
                 return SinglePoseDetectionModel()
             }
         }
@@ -1124,7 +1124,10 @@ public object ONNXModels {
  * Base type for [OnnxInferenceModel].
  */
 public interface OnnxModelType<T : InferenceModel, U : InferenceModel> : ModelType<T, U> {
-    public fun preInit(): OnnxInferenceModel
+    /**
+     * Creates a new instance of the [OnnxInferenceModel] according to this [ModelType].
+     */
+    public fun createModel(): OnnxInferenceModel
 }
 
 internal fun resNetOnnxPreprocessing(data: FloatArray, tensorShape: LongArray): FloatArray {

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
@@ -30,12 +30,12 @@ public object ONNXModels {
         override val inputColorMode: ColorMode = ColorMode.RGB,
         /** If true, model is shipped without last few layers and could be used for transfer learning and fine-tuning with TF Runtime. */
         internal var noTop: Boolean = false
-    ) : ModelType<T, ImageRecognitionModel> {
+    ) : OnnxModelType<T, ImageRecognitionModel> {
         override fun pretrainedModel(modelHub: ModelHub): ImageRecognitionModel {
             return ImageRecognitionModel(modelHub.loadModel(this), this)
         }
 
-        override fun preInit(): InferenceModel {
+        override fun preInit(): OnnxInferenceModel {
             return OnnxInferenceModel()
         }
 
@@ -620,7 +620,7 @@ public object ONNXModels {
         override val channelsFirst: Boolean = true,
         override val inputColorMode: ColorMode = ColorMode.RGB
     ) :
-        ModelType<T, U> {
+        OnnxModelType<T, U> {
         /**
          * This model is a real-time neural network for object detection that detects 80 different classes
          * (labels are available in [org.jetbrains.kotlinx.dl.dataset.handler.cocoCategoriesForSSD]).
@@ -973,7 +973,7 @@ public object ONNXModels {
         override val channelsFirst: Boolean = true,
         override val inputColorMode: ColorMode = ColorMode.RGB
     ) :
-        ModelType<T, U> {
+        OnnxModelType<T, U> {
         /**
          * This model is a neural network for face alignment that take RGB images of faces as input and produces coordinates of 106 faces landmarks.
          *
@@ -1006,7 +1006,7 @@ public object ONNXModels {
         override val channelsFirst: Boolean = true,
         override val inputColorMode: ColorMode = ColorMode.RGB
     ) :
-        ModelType<T, U> {
+        OnnxModelType<T, U> {
         /**
          * This model is a convolutional neural network model that runs on RGB images and predicts human joint locations of a single person.
          * (edges are available in [org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection.edgeKeyPointsPairs]
@@ -1118,6 +1118,13 @@ public object ONNXModels {
             }
         }
     }
+}
+
+/**
+ * Base type for [OnnxInferenceModel].
+ */
+public interface OnnxModelType<T : InferenceModel, U : InferenceModel> : ModelType<T, U> {
+    public fun preInit(): OnnxInferenceModel
 }
 
 internal fun resNetOnnxPreprocessing(data: FloatArray, tensorShape: LongArray): FloatArray {

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
@@ -35,8 +35,8 @@ public object ONNXModels {
             return ImageRecognitionModel(modelHub.loadModel(this), this)
         }
 
-        override fun createModel(): OnnxInferenceModel {
-            return OnnxInferenceModel()
+        override fun createModel(pathToModel: String): OnnxInferenceModel {
+            return OnnxInferenceModel(pathToModel)
         }
 
         /**
@@ -659,8 +659,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as SSDObjectDetectionModel
             }
 
-            override fun createModel(): SSDObjectDetectionModel {
-                return SSDObjectDetectionModel()
+            override fun createModel(pathToModel: String): SSDObjectDetectionModel {
+                return SSDObjectDetectionModel(pathToModel)
             }
         }
 
@@ -699,8 +699,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as SSDMobileNetV1ObjectDetectionModel
             }
 
-            override fun createModel(): SSDMobileNetV1ObjectDetectionModel {
-                val model = SSDMobileNetV1ObjectDetectionModel()
+            override fun createModel(pathToModel: String): SSDMobileNetV1ObjectDetectionModel {
+                val model = SSDMobileNetV1ObjectDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 1000L, 1000L, 3L)
                 return model
             }
@@ -737,8 +737,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun createModel(): EfficientDetObjectDetectionModel {
-                val model = EfficientDetObjectDetectionModel()
+            override fun createModel(pathToModel: String): EfficientDetObjectDetectionModel {
+                val model = EfficientDetObjectDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 512L, 512L, 3L)
                 return model
             }
@@ -774,8 +774,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun createModel(): EfficientDetObjectDetectionModel {
-                val model = EfficientDetObjectDetectionModel()
+            override fun createModel(pathToModel: String): EfficientDetObjectDetectionModel {
+                val model = EfficientDetObjectDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 640L, 640L, 3L)
                 return model
             }
@@ -811,8 +811,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun createModel(): EfficientDetObjectDetectionModel {
-                val model = EfficientDetObjectDetectionModel()
+            override fun createModel(pathToModel: String): EfficientDetObjectDetectionModel {
+                val model = EfficientDetObjectDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 768L, 768L, 3L)
                 return model
             }
@@ -848,8 +848,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun createModel(): EfficientDetObjectDetectionModel {
-                val model = EfficientDetObjectDetectionModel()
+            override fun createModel(pathToModel: String): EfficientDetObjectDetectionModel {
+                val model = EfficientDetObjectDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 896L, 896L, 3L)
                 return model
             }
@@ -885,8 +885,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun createModel(): EfficientDetObjectDetectionModel {
-                val model = EfficientDetObjectDetectionModel()
+            override fun createModel(pathToModel: String): EfficientDetObjectDetectionModel {
+                val model = EfficientDetObjectDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 1024L, 1024L, 3L)
                 return model
             }
@@ -922,8 +922,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun createModel(): EfficientDetObjectDetectionModel {
-                val model = EfficientDetObjectDetectionModel()
+            override fun createModel(pathToModel: String): EfficientDetObjectDetectionModel {
+                val model = EfficientDetObjectDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 1280L, 1280L, 3L)
                 return model
             }
@@ -959,8 +959,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as EfficientDetObjectDetectionModel
             }
 
-            override fun createModel(): EfficientDetObjectDetectionModel {
-                val model = EfficientDetObjectDetectionModel()
+            override fun createModel(pathToModel: String): EfficientDetObjectDetectionModel {
+                val model = EfficientDetObjectDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 1280L, 1280L, 3L)
                 return model
             }
@@ -994,8 +994,8 @@ public object ONNXModels {
                 return Fan2D106FaceAlignmentModel(modelHub.loadModel(this))
             }
 
-            override fun createModel(): OnnxInferenceModel {
-                return OnnxInferenceModel()
+            override fun createModel(pathToModel: String): OnnxInferenceModel {
+                return OnnxInferenceModel(pathToModel)
             }
         }
     }
@@ -1037,8 +1037,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as SinglePoseDetectionModel
             }
 
-            override fun createModel(): SinglePoseDetectionModel {
-                return SinglePoseDetectionModel()
+            override fun createModel(pathToModel: String): SinglePoseDetectionModel {
+                return SinglePoseDetectionModel(pathToModel)
             }
         }
 
@@ -1076,8 +1076,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as MultiPoseDetectionModel
             }
 
-            override fun createModel(): MultiPoseDetectionModel {
-                val model = MultiPoseDetectionModel()
+            override fun createModel(pathToModel: String): MultiPoseDetectionModel {
+                val model = MultiPoseDetectionModel(pathToModel)
                 model.inputShape = longArrayOf(1L, 256L, 256L, 3L)
                 return model
             }
@@ -1113,8 +1113,8 @@ public object ONNXModels {
                 return modelHub.loadModel(this) as SinglePoseDetectionModel
             }
 
-            override fun createModel(): SinglePoseDetectionModel {
-                return SinglePoseDetectionModel()
+            override fun createModel(pathToModel: String): SinglePoseDetectionModel {
+                return SinglePoseDetectionModel(pathToModel)
             }
         }
     }
@@ -1126,8 +1126,9 @@ public object ONNXModels {
 public interface OnnxModelType<T : InferenceModel, U : InferenceModel> : ModelType<T, U> {
     /**
      * Creates a new instance of the [OnnxInferenceModel] according to this [ModelType].
+     * @param pathToModel path to the model file
      */
-    public fun createModel(): OnnxInferenceModel
+    public fun createModel(pathToModel: String): OnnxInferenceModel
 }
 
 internal fun resNetOnnxPreprocessing(data: FloatArray, tensorShape: LongArray): FloatArray {

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModel.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModel.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlinx.dl.api.extension.argmax
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders.ExecutionProvider
 import org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders.ExecutionProvider.CPU
-import org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders.ExecutionProvider.CUDA
 import java.nio.*
 import java.util.*
 
@@ -122,14 +121,7 @@ public open class OnnxInferenceModel(private val pathToModel: String) : Inferenc
     private fun buildSessionOptions(uniqueProviders: List<ExecutionProvider>): SessionOptions {
         val sessionOptions = SessionOptions()
         for (provider in uniqueProviders) {
-            when (provider) {
-                is CUDA -> {
-                    sessionOptions.addCUDA(provider.deviceId)
-                }
-                is CPU -> {
-                    sessionOptions.addCPU(provider.useBFCArenaAllocator)
-                }
-            }
+            provider.addOptionsTo(sessionOptions)
         }
         return sessionOptions
     }

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModel.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModel.kt
@@ -26,7 +26,7 @@ private const val RESHAPE_MISSED_MESSAGE = "Model input shape is not defined. Ca
  *
  * @since 0.3
  */
-public open class OnnxInferenceModel : InferenceModel() {
+public open class OnnxInferenceModel(private val pathToModel: String) : InferenceModel() {
     /** Logger for the model. */
     private val logger: KLogger = KotlinLogging.logger {}
 
@@ -54,8 +54,6 @@ public open class OnnxInferenceModel : InferenceModel() {
     public lateinit var outputDataType: OnnxJavaType
         private set
 
-    private lateinit var pathToModel: String
-
     /** Execution providers currently set for the model. */
     private lateinit var executionProvidersInUse: List<ExecutionProvider>
 
@@ -67,21 +65,19 @@ public open class OnnxInferenceModel : InferenceModel() {
             pathToModel: String,
             vararg executionProviders: ExecutionProvider = arrayOf(CPU(true))
         ): OnnxInferenceModel {
-            val model = OnnxInferenceModel()
+            val model = OnnxInferenceModel(pathToModel)
 
-            return initializeONNXModel(model, pathToModel, *executionProviders)
+            return initializeONNXModel(model, *executionProviders)
         }
 
         internal fun initializeONNXModel(
             model: OnnxInferenceModel,
-            pathToModel: String,
             vararg executionProviders: ExecutionProvider = arrayOf(CPU(true))
         ): OnnxInferenceModel {
             require(!model::env.isInitialized) { "The model $model is initialized!" }
             require(!model::session.isInitialized) { "The model $model is initialized!" }
 
             model.env = OrtEnvironment.getEnvironment()
-            model.pathToModel = pathToModel
 
             model.reinitializeWith(*executionProviders)
             model.initInputOutputInfo()

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModel.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModel.kt
@@ -34,7 +34,7 @@ public open class OnnxInferenceModel(private val pathToModel: String) : Inferenc
      * The host object for the onnx-runtime system. Can create [session] which encapsulate
      * specific models.
      */
-    private lateinit var env: OrtEnvironment
+    private val env = OrtEnvironment.getEnvironment()
 
     /** Wraps an ONNX model and allows inference calls. */
     private lateinit var session: OrtSession
@@ -74,10 +74,7 @@ public open class OnnxInferenceModel(private val pathToModel: String) : Inferenc
             model: OnnxInferenceModel,
             vararg executionProviders: ExecutionProvider = arrayOf(CPU(true))
         ): OnnxInferenceModel {
-            require(!model::env.isInitialized) { "The model $model is initialized!" }
             require(!model::session.isInitialized) { "The model $model is initialized!" }
-
-            model.env = OrtEnvironment.getEnvironment()
 
             model.reinitializeWith(*executionProviders)
             model.initInputOutputInfo()
@@ -115,7 +112,6 @@ public open class OnnxInferenceModel(private val pathToModel: String) : Inferenc
      * @param executionProviders list of execution providers to use.
      */
     public fun reinitializeWith(vararg executionProviders: ExecutionProvider) {
-        require(::env.isInitialized) { "The model $this is not initialized!" }
         for (executionProvider in executionProviders) {
             require(executionProvider.internalProviderId in OrtEnvironment.getAvailableProviders()) {
                 "The optimized execution provider $executionProvider is not available in the current environment!"

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModelEx.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModelEx.kt
@@ -11,7 +11,7 @@ public inline fun <R> OnnxInferenceModel.inferAndCloseUsing(
     vararg providers: ExecutionProvider,
     block: (OnnxInferenceModel) -> R
 ): R {
-    this.reinitializeWith(*providers)
+    this.initializeWith(*providers)
     return this.use(block)
 }
 
@@ -19,7 +19,7 @@ public inline fun <R> OnnxInferenceModel.inferAndCloseUsing(
     providers: List<ExecutionProvider>,
     block: (OnnxInferenceModel) -> R
 ): R {
-    this.reinitializeWith(*providers.toTypedArray())
+    this.initializeWith(*providers.toTypedArray())
     return this.use(block)
 }
 
@@ -27,7 +27,7 @@ public inline fun <R> OnnxInferenceModel.inferUsing(
     vararg providers: ExecutionProvider,
     block: (OnnxInferenceModel) -> R
 ): R {
-    this.reinitializeWith(*providers)
+    this.initializeWith(*providers)
     return this.run(block)
 }
 
@@ -35,6 +35,6 @@ public inline fun <R> OnnxInferenceModel.inferUsing(
     providers: List<ExecutionProvider>,
     block: (OnnxInferenceModel) -> R
 ): R {
-    this.reinitializeWith(*providers.toTypedArray())
+    this.initializeWith(*providers.toTypedArray())
     return this.run(block)
 }

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/executionproviders/ExecutionProviders.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/executionproviders/ExecutionProviders.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders
 
 import ai.onnxruntime.OrtProvider
+import ai.onnxruntime.OrtSession
 
 /**
  * These are classes representing the supported ONNXRuntime execution providers for KotlinDL.
@@ -16,7 +17,11 @@ public sealed class ExecutionProvider(public val internalProviderId: OrtProvider
      *  @param useBFCArenaAllocator If true, the CPU provider will use BFC arena allocator.
      *  @see [OrtProvider.CPU]
      */
-    public data class CPU(public val useBFCArenaAllocator: Boolean = true) : ExecutionProvider(OrtProvider.CPU)
+    public data class CPU(public val useBFCArenaAllocator: Boolean = true) : ExecutionProvider(OrtProvider.CPU) {
+        override fun addOptionsTo(sessionOptions: OrtSession.SessionOptions) {
+            sessionOptions.addCPU(useBFCArenaAllocator)
+        }
+    }
 
     /**
      *  CUDA execution provider.
@@ -24,5 +29,14 @@ public sealed class ExecutionProvider(public val internalProviderId: OrtProvider
      *  @param deviceId The device ID to use.
      *  @see [OrtProvider.CUDA]
      */
-    public data class CUDA(public val deviceId: Int = 0) : ExecutionProvider(OrtProvider.CUDA)
+    public data class CUDA(public val deviceId: Int = 0) : ExecutionProvider(OrtProvider.CUDA) {
+        override fun addOptionsTo(sessionOptions: OrtSession.SessionOptions) {
+            sessionOptions.addCUDA(deviceId)
+        }
+    }
+
+    /**
+     * Adds execution provider options to the [OrtSession.SessionOptions].
+     */
+    public open fun addOptionsTo(sessionOptions: OrtSession.SessionOptions): Unit = Unit
 }

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/EfficientDetObjectDetectionModel.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/EfficientDetObjectDetectionModel.kt
@@ -26,7 +26,7 @@ private const val OUTPUT_NAME = "detections:0"
  *
  * @since 0.4
  */
-public class EfficientDetObjectDetectionModel : OnnxInferenceModel() {
+public class EfficientDetObjectDetectionModel(pathToModel: String) : OnnxInferenceModel(pathToModel) {
     /**
      * Returns the detected object for the given image file sorted by the score.
      *

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDMobileNetV1ObjectDetectionModel.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDMobileNetV1ObjectDetectionModel.kt
@@ -29,7 +29,7 @@ private const val OUTPUT_NUMBER_OF_DETECTIONS = "num_detections:0"
  *
  * @since 0.4
  */
-public class SSDMobileNetV1ObjectDetectionModel : OnnxInferenceModel() {
+public class SSDMobileNetV1ObjectDetectionModel(pathToModel: String) : OnnxInferenceModel(pathToModel) {
     /**
      * Returns the top N detected object for the given image file sorted by the score.
      *

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDObjectDetectionModel.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDObjectDetectionModel.kt
@@ -36,7 +36,7 @@ private const val INPUT_SIZE = 1200
  *
  * @since 0.3
  */
-public class SSDObjectDetectionModel : OnnxInferenceModel() {
+public class SSDObjectDetectionModel(pathToModel: String) : OnnxInferenceModel(pathToModel) {
     /**
      * Returns the top N detected object for the given image file sorted by the score.
      *

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModel.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModel.kt
@@ -28,7 +28,7 @@ private const val INPUT_SIZE = 256
  *
  * It internally uses [ONNXModels.PoseDetection.MoveNetMultiPoseLighting] under the hood to make predictions.
  */
-public class MultiPoseDetectionModel : OnnxInferenceModel() {
+public class MultiPoseDetectionModel(pathToModel: String) : OnnxInferenceModel(pathToModel) {
     public fun detectPoses(inputData: FloatArray, confidence: Float = 0.005f): MultiPoseDetectionResult {
         val rawPrediction = this.predictRaw(inputData)
         val rawPoseLandMarks = (rawPrediction[OUTPUT_NAME] as Array<Array<FloatArray>>)[0]

--- a/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModel.kt
+++ b/onnx/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModel.kt
@@ -26,7 +26,7 @@ private const val OUTPUT_NAME = "output_0"
  * It internally uses [ONNXModels.PoseDetection.MoveNetSinglePoseLighting]
  * or [ONNXModels.PoseDetection.MoveNetSinglePoseThunder] under the hood to make predictions.
  */
-public class SinglePoseDetectionModel : OnnxInferenceModel() {
+public class SinglePoseDetectionModel(pathToModel: String) : OnnxInferenceModel(pathToModel) {
     public fun detectPose(inputData: FloatArray): DetectedPose {
         val rawPrediction = this.predictRaw(inputData)
         val rawPoseLandMarks = (rawPrediction[OUTPUT_NAME] as Array<Array<Array<FloatArray>>>)[0][0]


### PR DESCRIPTION
1. `OnnxModelType` is introduced to represent the type of onnx models. This interface now has a method to create a model.
2. `OnnxInferenceModel` receives path in constructor and creates `OrtEnvironment` immediately.
3. `initializeONNXModel` function is merged with `reinitializeWith` to simplify usage of the model.
4. `addOptionsTo` function is added to `ExecutionProvider`. This allows to simplify construction of the `SessionOptions` in the model, since we don't need to enumerate all providers anymore. This a new addition to the proposal in #413.

Fixes #413