### PR TITLE
Introduce an interface for loading and preprocessing data

### DIFF
--- a/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModel.kt
+++ b/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModel.kt
@@ -79,7 +79,7 @@ public class ImageRecognitionModel(
      *
      * @return The list of pairs <label, probability> sorted from the most probable to the lowest probable.
      */
-    public fun predictTopKObjects(imageFile: File, dataLoader: DataLoader, topK: Int = 5): List<Pair<String, Float>> {
+    public fun predictTopKObjects(imageFile: File, dataLoader: DataLoader<File>, topK: Int = 5): List<Pair<String, Float>> {
         val (inputData, _) = dataLoader.load(imageFile)
         return predictTopKImageNetLabels(internalModel, inputData, imageNetClassLabels, topK)
     }
@@ -126,7 +126,7 @@ public class ImageRecognitionModel(
      *
      * @return The label of the recognized object with the highest probability.
      */
-    public fun predictObject(imageFile: File, dataLoader: DataLoader): String {
+    public fun predictObject(imageFile: File, dataLoader: DataLoader<File>): String {
         val (inputData, _) = dataLoader.load(imageFile)
         return imageNetClassLabels[internalModel.predict(inputData)]!!
     }

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/core/shape/TensorShape.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/core/shape/TensorShape.kt
@@ -246,4 +246,4 @@ public fun getDimsOfArray(data: kotlin.Array<*>): LongArray {
 /**
  * @see getDimsOfArray
  */
-internal val Array<*>.tensorShape: TensorShape get() = TensorShape(getDimsOfArray(this))
+public val Array<*>.tensorShape: TensorShape get() = TensorShape(getDimsOfArray(this))

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataLoader.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataLoader.kt
@@ -6,19 +6,19 @@
 package org.jetbrains.kotlinx.dl.dataset
 
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
-import java.io.File
 
 /**
- * And interface for loading data from [File].
+ * And interface for loading data from the provided data source.
+ * @param D data source type
  */
-public interface DataLoader {
+public interface DataLoader<D> {
     /**
-     * Load the data from the specified [file].
+     * Load the data from the specified [dataSource].
      */
-    public fun load(file: File): Pair<FloatArray, TensorShape>
+    public fun load(dataSource: D): Pair<FloatArray, TensorShape>
 
     public companion object {
-        internal fun DataLoader.prepareX(sources: Array<File>): Array<FloatArray> {
+        internal fun <D> DataLoader<D>.prepareX(sources: Array<D>): Array<FloatArray> {
             return Array(sources.size) { load(sources[it]).first }
         }
     }

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataLoader.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataLoader.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.dataset
+
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import java.io.File
+
+/**
+ * And interface for loading data from [File].
+ */
+public interface DataLoader {
+    /**
+     * Load the data from the specified [file].
+     */
+    public fun load(file: File): Pair<FloatArray, TensorShape>
+
+    public companion object {
+        internal fun DataLoader.prepareX(sources: Array<File>): Array<FloatArray> {
+            return Array(sources.size) { load(sources[it]).first }
+        }
+    }
+}

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlinx.dl.dataset
 
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.Preprocessing
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.generator.LabelGenerator
+import org.jetbrains.kotlinx.dl.dataset.preprocessor.generator.LabelGenerator.Companion.prepareY
 import java.io.File
 import java.io.IOException
 import java.nio.FloatBuffer
@@ -137,7 +138,7 @@ public class OnFlyImageDataset internal constructor(
         ): OnFlyImageDataset {
             return try {
                 val xFiles = OnHeapDataset.prepareFileNames(pathToData)
-                val y = OnHeapDataset.prepareY(xFiles, labelGenerator)
+                val y = labelGenerator.prepareY(xFiles)
                 OnFlyImageDataset(xFiles, y, preprocessors)
             } catch (e: IOException) {
                 throw AssertionError(e)

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
@@ -60,6 +60,35 @@ public class OnFlyImageDataset internal constructor(
         return Pair(train, test)
     }
 
+    /** Returns amount of data rows. */
+    override fun xSize(): Int {
+        return xFiles.size
+    }
+
+    /** Returns row by index [idx]. */
+    override fun getX(idx: Int): FloatArray {
+        return applyImagePreprocessing(xFiles[idx])
+    }
+
+    /** Returns label as [FloatArray] by index [idx]. */
+    override fun getY(idx: Int): Float {
+        return y[idx]
+    }
+
+    override fun shuffle(): OnFlyImageDataset {
+        xFiles.shuffle(Random(12L))
+        y.shuffle(Random(12L))
+        return this
+    }
+
+    override fun createDataBatch(batchStart: Int, batchLength: Int): DataBatch {
+        return DataBatch(
+            copyImagesToBatch(xFiles, batchStart, batchLength),
+            copyLabelsToBatch(y, batchStart, batchLength),
+            batchLength
+        )
+    }
+
     public companion object {
         /** Creates binary vector with size [numClasses] from [label]. */
         @JvmStatic
@@ -114,34 +143,5 @@ public class OnFlyImageDataset internal constructor(
                 throw AssertionError(e)
             }
         }
-    }
-
-    /** Returns amount of data rows. */
-    override fun xSize(): Int {
-        return xFiles.size
-    }
-
-    /** Returns row by index [idx]. */
-    override fun getX(idx: Int): FloatArray {
-        return applyImagePreprocessing(xFiles[idx])
-    }
-
-    /** Returns label as [FloatArray] by index [idx]. */
-    override fun getY(idx: Int): Float {
-        return y[idx]
-    }
-
-    override fun shuffle(): OnFlyImageDataset {
-        xFiles.shuffle(Random(12L))
-        y.shuffle(Random(12L))
-        return this
-    }
-
-    override fun createDataBatch(batchStart: Int, batchLength: Int): DataBatch {
-        return DataBatch(
-            copyImagesToBatch(xFiles, batchStart, batchLength),
-            copyLabelsToBatch(y, batchStart, batchLength),
-            batchLength
-        )
     }
 }

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
@@ -18,18 +18,18 @@ import kotlin.random.Random
 /**
  * This dataset keeps all data on disk and generates batches on the fly using provided [dataLoader].
  *
- * @param [xFiles] files to load images from
- * @param [y] labels to use for the loaded images
- * @param [dataLoader] loader to load the data with from the provided files
+ * @param [x] sources to load data from
+ * @param [y] labels to use for the loaded data
+ * @param [dataLoader] data loader to load data with from the provided sources
  */
-public class OnFlyImageDataset internal constructor(
-    private val xFiles: Array<File>,
+public class OnFlyImageDataset<D> internal constructor(
+    private val x: Array<D>,
     private val y: FloatArray,
-    private val dataLoader: DataLoader,
+    private val dataLoader: DataLoader<D>,
 ) : Dataset() {
 
     /** Converts [src] to [FloatBuffer] from [start] position for the next [length] positions. */
-    private fun copyImagesToBatch(src: Array<File>, start: Int, length: Int): Array<FloatArray> {
+    private fun copySourcesToBatch(src: Array<D>, start: Int, length: Int): Array<FloatArray> {
         return Array(length) { index -> dataLoader.load(src[start + index]).first }
     }
 
@@ -39,18 +39,18 @@ public class OnFlyImageDataset internal constructor(
     }
 
     /** Splits datasets on two sub-datasets according [splitRatio].*/
-    override fun split(splitRatio: Double): Pair<OnFlyImageDataset, OnFlyImageDataset> {
+    override fun split(splitRatio: Double): Pair<OnFlyImageDataset<D>, OnFlyImageDataset<D>> {
         require(splitRatio in 0.0..1.0) { "'Split ratio' argument value must be in range [0.0; 1.0]." }
 
-        val trainDatasetLastIndex = truncate(xFiles.size * splitRatio).toInt()
+        val trainDatasetLastIndex = truncate(x.size * splitRatio).toInt()
 
         val train = OnFlyImageDataset(
-            xFiles.copyOfRange(0, trainDatasetLastIndex),
+            x.copyOfRange(0, trainDatasetLastIndex),
             y.copyOfRange(0, trainDatasetLastIndex),
             dataLoader
         )
         val test = OnFlyImageDataset(
-            xFiles.copyOfRange(trainDatasetLastIndex, xFiles.size),
+            x.copyOfRange(trainDatasetLastIndex, x.size),
             y.copyOfRange(trainDatasetLastIndex, y.size),
             dataLoader
         )
@@ -60,12 +60,12 @@ public class OnFlyImageDataset internal constructor(
 
     /** Returns amount of data rows. */
     override fun xSize(): Int {
-        return xFiles.size
+        return x.size
     }
 
     /** Returns row by index [idx]. */
     override fun getX(idx: Int): FloatArray {
-        return dataLoader.load(xFiles[idx]).first
+        return dataLoader.load(x[idx]).first
     }
 
     /** Returns label as [FloatArray] by index [idx]. */
@@ -73,15 +73,15 @@ public class OnFlyImageDataset internal constructor(
         return y[idx]
     }
 
-    override fun shuffle(): OnFlyImageDataset {
-        xFiles.shuffle(Random(12L))
+    override fun shuffle(): OnFlyImageDataset<D> {
+        x.shuffle(Random(12L))
         y.shuffle(Random(12L))
         return this
     }
 
     override fun createDataBatch(batchStart: Int, batchLength: Int): DataBatch {
         return DataBatch(
-            copyImagesToBatch(xFiles, batchStart, batchLength),
+            copySourcesToBatch(x, batchStart, batchLength),
             copyLabelsToBatch(y, batchStart, batchLength),
             batchLength
         )
@@ -116,7 +116,7 @@ public class OnFlyImageDataset internal constructor(
             pathToData: File,
             labels: FloatArray,
             preprocessing: Preprocessing = Preprocessing()
-        ): OnFlyImageDataset {
+        ): OnFlyImageDataset<File> {
             return try {
                 OnFlyImageDataset(OnHeapDataset.prepareFileNames(pathToData), labels, preprocessing.dataLoader())
             } catch (e: IOException) {
@@ -130,9 +130,9 @@ public class OnFlyImageDataset internal constructor(
         @JvmStatic
         public fun create(
             pathToData: File,
-            labelGenerator: LabelGenerator,
+            labelGenerator: LabelGenerator<File>,
             preprocessing: Preprocessing = Preprocessing()
-        ): OnFlyImageDataset {
+        ): OnFlyImageDataset<File> {
             return try {
                 val xFiles = OnHeapDataset.prepareFileNames(pathToData)
                 val y = labelGenerator.prepareY(xFiles)

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
@@ -230,7 +230,7 @@ public class OnHeapDataset internal constructor(public val x: Array<FloatArray>,
         @JvmStatic
         public fun create(
             pathToData: File,
-            labelGenerator: LabelGenerator,
+            labelGenerator: LabelGenerator<File>,
             preprocessing: Preprocessing = Preprocessing()
         ): OnHeapDataset {
             return try {

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
@@ -59,6 +59,35 @@ public class OnHeapDataset internal constructor(public val x: Array<FloatArray>,
         )
     }
 
+    /** Returns amount of data rows. */
+    override fun xSize(): Int {
+        return x.size
+    }
+
+    /** Returns row by index [idx]. */
+    override fun getX(idx: Int): FloatArray {
+        return x[idx]
+    }
+
+    /** Returns label as [FloatArray] by index [idx]. */
+    override fun getY(idx: Int): Float {
+        return y[idx]
+    }
+
+    override fun shuffle(): OnHeapDataset {
+        x.shuffle(Random(12L))
+        y.shuffle(Random(12L))
+        return this
+    }
+
+    override fun createDataBatch(batchStart: Int, batchLength: Int): DataBatch {
+        return DataBatch(
+            copyXToBatch(x, batchStart, batchLength),
+            copyLabelsToBatch(y, batchStart, batchLength),
+            batchLength
+        )
+    }
+
     public companion object {
         /** Creates binary vector with size [numClasses] from [label]. */
         @JvmStatic
@@ -255,35 +284,6 @@ public class OnHeapDataset internal constructor(public val x: Array<FloatArray>,
                 .toList()
                 .toTypedArray()
         }
-    }
-
-    /** Returns amount of data rows. */
-    override fun xSize(): Int {
-        return x.size
-    }
-
-    /** Returns row by index [idx]. */
-    override fun getX(idx: Int): FloatArray {
-        return x[idx]
-    }
-
-    /** Returns label as [FloatArray] by index [idx]. */
-    override fun getY(idx: Int): Float {
-        return y[idx]
-    }
-
-    override fun shuffle(): OnHeapDataset {
-        x.shuffle(Random(12L))
-        y.shuffle(Random(12L))
-        return this
-    }
-
-    override fun createDataBatch(batchStart: Int, batchLength: Int): DataBatch {
-        return DataBatch(
-            copyXToBatch(x, batchStart, batchLength),
-            copyLabelsToBatch(y, batchStart, batchLength),
-            batchLength
-        )
     }
 }
 

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
@@ -5,9 +5,9 @@
 
 package org.jetbrains.kotlinx.dl.dataset
 
+import org.jetbrains.kotlinx.dl.dataset.DataLoader.Companion.prepareX
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.Preprocessing
-import org.jetbrains.kotlinx.dl.dataset.preprocessor.generator.EmptyLabels
-import org.jetbrains.kotlinx.dl.dataset.preprocessor.generator.FromFolders
+import org.jetbrains.kotlinx.dl.dataset.preprocessor.dataLoader
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.generator.LabelGenerator
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.generator.LabelGenerator.Companion.prepareY
 import java.io.File
@@ -28,8 +28,7 @@ import kotlin.streams.toList
  * @property [x] an array of feature vectors
  * @property [y] an array of labels
  */
-public class OnHeapDataset internal constructor(public val x: Array<FloatArray>, public val y: FloatArray) :
-    Dataset() {
+public class OnHeapDataset internal constructor(public val x: Array<FloatArray>, public val y: FloatArray) : Dataset() {
 
     /** Converts [src] to [FloatBuffer] from [start] position for the next [length] positions. */
     private fun copyXToBatch(src: Array<FloatArray>, start: Int, length: Int): Array<FloatArray> {
@@ -217,21 +216,13 @@ public class OnHeapDataset internal constructor(public val x: Array<FloatArray>,
         ): OnHeapDataset {
             return try {
                 val xFiles = prepareFileNames(pathToData)
-                val x = prepareX(xFiles, preprocessing)
+                val x = preprocessing.dataLoader().prepareX(xFiles)
 
                 OnHeapDataset(x, labels)
             } catch (e: IOException) {
                 throw AssertionError(e)
             }
         }
-
-        private fun prepareX(
-            xFiles: Array<File>,
-            preprocessors: Preprocessing
-        ): Array<FloatArray> {
-            return Array(xFiles.size) { preprocessors.handleFile(xFiles[it]).first }
-        }
-
 
         /**
          * Creates an [OnHeapDataset] from [pathToData] and [labelGenerator] with [preprocessing] to prepare images.
@@ -244,7 +235,7 @@ public class OnHeapDataset internal constructor(public val x: Array<FloatArray>,
         ): OnHeapDataset {
             return try {
                 val xFiles = prepareFileNames(pathToData)
-                val x = prepareX(xFiles, preprocessing)
+                val x = preprocessing.dataLoader().prepareX(xFiles)
                 val y = labelGenerator.prepareY(xFiles)
 
                 OnHeapDataset(x, y)

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/ImageShape.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/ImageShape.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor
 
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+
 /**
  * Helper class to keep widely used shape of image object presented as a 4D tensor
  * (batchSize = 1, [width], [height], [channels]).
@@ -24,4 +26,10 @@ public data class ImageShape(
     /** Returns number of elements in a tensor with the given shape. */
     public val numberOfElements: Long
         get() = width!! * height!! * channels!!
+
+    public companion object {
+        internal fun ImageShape.toTensorShape(): TensorShape {
+            return TensorShape(width!!, height!!, channels!!)
+        }
+    }
 }

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/Preprocessing.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/Preprocessing.kt
@@ -5,8 +5,11 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor
 
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.DataLoader
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
 import org.jetbrains.kotlinx.dl.dataset.image.getShape
+import org.jetbrains.kotlinx.dl.dataset.preprocessor.ImageShape.Companion.toTensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.ImagePreprocessing
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.ImagePreprocessorBase
 import java.awt.image.BufferedImage

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.dataset.preprocessor
+
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.DataLoader
+import org.jetbrains.kotlinx.dl.dataset.preprocessor.ImageShape.Companion.toTensorShape
+import java.io.File
+
+/**
+ * A [DataLoader] which uses provided [Preprocessing] to prepare images.
+ */
+private class PreprocessingDataLoader(private val preprocessing: Preprocessing) : DataLoader {
+    override fun load(file: File): Pair<FloatArray, TensorShape> {
+        val (floats, imageShape) = preprocessing(file)
+        return floats to imageShape.toTensorShape()
+    }
+}
+
+/**
+ * Returns a [DataLoader] instance which uses this [Preprocessing] to prepare images.
+ */
+public fun Preprocessing.dataLoader(): DataLoader = PreprocessingDataLoader(this)

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
@@ -13,9 +13,9 @@ import java.io.File
 /**
  * A [DataLoader] which uses provided [Preprocessing] to prepare images.
  */
-private class PreprocessingDataLoader(private val preprocessing: Preprocessing) : DataLoader {
-    override fun load(file: File): Pair<FloatArray, TensorShape> {
-        val (floats, imageShape) = preprocessing(file)
+private class PreprocessingDataLoader(private val preprocessing: Preprocessing) : DataLoader<File> {
+    override fun load(dataSource: File): Pair<FloatArray, TensorShape> {
+        val (floats, imageShape) = preprocessing(dataSource)
         return floats to imageShape.toTensorShape()
     }
 }
@@ -23,4 +23,4 @@ private class PreprocessingDataLoader(private val preprocessing: Preprocessing) 
 /**
  * Returns a [DataLoader] instance which uses this [Preprocessing] to prepare images.
  */
-public fun Preprocessing.dataLoader(): DataLoader = PreprocessingDataLoader(this)
+public fun Preprocessing.dataLoader(): DataLoader<File> = PreprocessingDataLoader(this)

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/EmptyLabels.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/EmptyLabels.kt
@@ -10,6 +10,6 @@ import java.io.File
 /**
  * This [LabelGenerator] is responsible for creation default labels with value Float.NaN.
  */
-public class EmptyLabels : LabelGenerator {
-    override fun getLabel(file: File): Float = Float.NaN
+public class EmptyLabels<D> : LabelGenerator<D> {
+    override fun getLabel(dataSource: D): Float = Float.NaN
 }

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/EmptyLabels.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/EmptyLabels.kt
@@ -5,7 +5,11 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.generator
 
+import java.io.File
+
 /**
  * This [LabelGenerator] is responsible for creation default labels with value Float.NaN.
  */
-public class EmptyLabels : LabelGenerator
+public class EmptyLabels : LabelGenerator {
+    override fun getLabel(file: File): Float = Float.NaN
+}

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/FromFolders.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/FromFolders.kt
@@ -5,10 +5,21 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.generator
 
+import java.io.File
+
 /**
  * This [LabelGenerator] is responsible for extracting labels from the names of folders where the images of the appropriate class are located.
  * It keeps the [mapping] name of classes to int numbers.
  *
  * @property [mapping] The mapping from class names to class labels presented as natural numbers.
  */
-public class FromFolders(public val mapping: Map<String, Int>) : LabelGenerator
+public class FromFolders(public val mapping: Map<String, Int>) : LabelGenerator {
+    override fun getLabel(file: File): Float {
+        val label = mapping[file.parentFile.name]
+        if (label == null) {
+            error("The parent directory of ${file.absolutePath} is ${file.parentFile.name}. No such class name in mapping $mapping")
+        }
+        return label.toFloat()
+    }
+}
+

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/FromFolders.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/FromFolders.kt
@@ -13,11 +13,11 @@ import java.io.File
  *
  * @property [mapping] The mapping from class names to class labels presented as natural numbers.
  */
-public class FromFolders(public val mapping: Map<String, Int>) : LabelGenerator {
-    override fun getLabel(file: File): Float {
-        val label = mapping[file.parentFile.name]
+public class FromFolders(public val mapping: Map<String, Int>) : LabelGenerator<File> {
+    override fun getLabel(dataSource: File): Float {
+        val label = mapping[dataSource.parentFile.name]
         if (label == null) {
-            error("The parent directory of ${file.absolutePath} is ${file.parentFile.name}. No such class name in mapping $mapping")
+            error("The parent directory of ${dataSource.absolutePath} is ${dataSource.parentFile.name}. No such class name in mapping $mapping")
         }
         return label.toFloat()
     }

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/LabelGenerator.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/LabelGenerator.kt
@@ -5,5 +5,18 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.generator
 
+import java.io.File
+
 /** A parent interface for all label generators. */
-public interface LabelGenerator
+public interface LabelGenerator {
+    /**
+     * Returns a label for the provided [file].
+     */
+    public fun getLabel(file: File): Float
+
+    public companion object {
+        internal fun LabelGenerator.prepareY(sources: Array<File>): FloatArray {
+            return FloatArray(sources.size) { getLabel(sources[it]) }
+        }
+    }
+}

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/LabelGenerator.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/generator/LabelGenerator.kt
@@ -8,14 +8,14 @@ package org.jetbrains.kotlinx.dl.dataset.preprocessor.generator
 import java.io.File
 
 /** A parent interface for all label generators. */
-public interface LabelGenerator {
+public interface LabelGenerator<D> {
     /**
-     * Returns a label for the provided [file].
+     * Returns a label for the provided [dataSource].
      */
-    public fun getLabel(file: File): Float
+    public fun getLabel(dataSource: D): Float
 
     public companion object {
-        internal fun LabelGenerator.prepareY(sources: Array<File>): FloatArray {
+        internal fun <D> LabelGenerator<D>.prepareY(sources: Array<D>): FloatArray {
             return FloatArray(sources.size) { getLabel(sources[it]) }
         }
     }


### PR DESCRIPTION
This PR introduces a `DataLoader` interface which represents the abstraction for loading data in a form of `FloatArray` with a `TensorShape` from some source, e.g. a file. Currently this is done in one step: loading and preprocessing together and there is no access to the intermediate data (e.g. `BufferedImage`). So far this seems OK to me, but we may want to change it in the future. Currently the interface is mainly used in the datasets, but I intend to use it for onnx models to make them more platform-independent (we should have another implementation which uses `Bitmap` as a data source for android).

After these changes `OnFlyImageDataset` needs a new name since it can work with any data now, not just images, and also "on fly" is not grammatically correct (should be "on the fly", and it also seems more like an adverb, not an adjective). My current candidates are `LazyDataset`, `LoadingDataset` and `LightweightDataset`.

Since `DataLoader` uses `TensorShape`, the latter had to be moved to the "dataset" module and it does not look too good. Perhaps, "api" module should not depend on the "dataset" and it should be the other way around.