### PR TITLE
Fix dependencies issue (#432)

### DIFF
--- a/api/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/ModelType.kt
+++ b/api/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/ModelType.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.keras.loaders
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Identity

--- a/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageNetPreprocessing.kt
+++ b/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageNetPreprocessing.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.imagerecognition
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.*
 
 /** TF-style preprocessing. */

--- a/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/InputType.kt
+++ b/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/InputType.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.imagerecognition
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 
 /**

--- a/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/onHeapDatasetExtensions.kt
+++ b/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/onHeapDatasetExtensions.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset
 
-import org.jetbrains.kotlinx.dl.api.core.shape.tensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.tensorShape
 import kotlin.math.roundToInt
 
 

--- a/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/ConvertToFloatArray.kt
+++ b/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/ConvertToFloatArray.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
 import android.graphics.Bitmap
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.argB8888ToNCHWArray
 import org.jetbrains.kotlinx.dl.dataset.image.argB8888ToNHWCArray
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.TensorLayout.NCHW
@@ -14,7 +14,7 @@ import org.jetbrains.kotlinx.dl.dataset.preprocessing.TensorLayout.NHWC
  *
  * @param layout [TensorLayout] of the resulting array.
  */
-public class ConvertToFloatArray(private var layout: TensorLayout = NCHW) :
+public class ConvertToFloatArray(public var layout: TensorLayout = NCHW) :
     Operation<Bitmap, Pair<FloatArray, TensorShape>> {
     private val channels = 3
     override fun apply(input: Bitmap): Pair<FloatArray, TensorShape> {

--- a/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/Preprocessing.kt
+++ b/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/Preprocessing.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
 import android.graphics.Bitmap
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.bitmap.Resize
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.bitmap.Rotate
 

--- a/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/bitmap/Resize.kt
+++ b/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/bitmap/Resize.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessing.bitmap
 
 import android.graphics.Bitmap
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 
 /**
@@ -21,8 +21,8 @@ import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
  * @property [outputHeight] The output height.
  */
 public class Resize(
-    private var outputWidth: Int = 100,
-    private var outputHeight: Int = 100,
+    public var outputWidth: Int = 100,
+    public var outputHeight: Int = 100,
 ) : Operation<Bitmap, Bitmap> {
     override fun apply(input: Bitmap): Bitmap {
         return Bitmap.createScaledBitmap(input, outputWidth, outputHeight, true)

--- a/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/bitmap/Rotate.kt
+++ b/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/bitmap/Rotate.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlinx.dl.dataset.preprocessing.bitmap
 
 import android.graphics.Bitmap
 import android.graphics.Matrix
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 
 /**
@@ -18,7 +18,7 @@ import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
  * @property [degrees] The rotation angle.
  */
 public class Rotate(
-    private var degrees: Float = 0.0f,
+    public var degrees: Float = 0.0f,
 ) : Operation<Bitmap, Bitmap> {
     override fun apply(input: Bitmap): Bitmap {
         val matrix = Matrix().apply { postRotate(degrees) }

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataLoader.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataLoader.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * And interface for loading data from the provided data source.

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/FloatArrayOperation.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/FloatArrayOperation.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * The aim of this class is to provide common functionality for all [Operation]s that can be applied to Pair<FloatArray, TensorShape>

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/FloatArrayPreprocessingDsl.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/FloatArrayPreprocessingDsl.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /** Applies [Normalizing] preprocessor to the tensor to normalize it with given mean and std values. */
 public fun<I> Operation<I, Pair<FloatArray, TensorShape>>.normalize(block: Normalizing.() -> Unit): Operation<I, Pair<FloatArray, TensorShape>> {

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/Normalizing.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/Normalizing.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import kotlin.math.sqrt
 
 /**

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/Operation.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/Operation.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * Interface for preprocessing operations.

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/OperationEx.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/OperationEx.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * Convenience functions for executing custom logic after applying [Operation].

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/PreprocessingPipeline.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/PreprocessingPipeline.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * This class is a special type of Operation which is used to build typesafe pipeline of preprocessing operations.

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/Rescaling.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/Rescaling.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessing
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 
 /**

--- a/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/shape/TensorShape.kt
+++ b/dataset/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/dataset/shape/TensorShape.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
-package org.jetbrains.kotlinx.dl.api.core.shape
+package org.jetbrains.kotlinx.dl.dataset.shape
 
 import kotlin.math.abs
 

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.fileLoader
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.generator.LabelGenerator

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.DataLoader.Companion.prepareX
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.fileLoader

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageUtil.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageUtil.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.dataset.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.ImageShape
 import java.awt.Graphics2D
 import java.awt.image.BufferedImage

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/ImageShape.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/ImageShape.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * Helper class to keep widely used shape of image object presented as a 4D tensor

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.DataLoader
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/CenterCrop.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/CenterCrop.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.copy
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import java.awt.image.BufferedImage

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Convert.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Convert.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.image.colorMode
 import org.jetbrains.kotlinx.dl.dataset.image.imageType

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/ConvertToFloatArray.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/ConvertToFloatArray.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
 import org.jetbrains.kotlinx.dl.dataset.image.getTensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Cropping.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Cropping.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.copy
 import org.jetbrains.kotlinx.dl.dataset.image.getTensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/ImagePreprocessingDsl.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/ImagePreprocessingDsl.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.PreprocessingPipeline

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Padding.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Padding.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.draw
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import java.awt.Color

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Resize.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Resize.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Rotate.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/image/Rotate.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor.image
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import java.awt.RenderingHints
 import java.awt.geom.AffineTransform

--- a/dataset/src/jvmTest/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingFinalShapeTest.kt
+++ b/dataset/src/jvmTest/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingFinalShapeTest.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.*

--- a/dataset/src/jvmTest/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingTensorTest.kt
+++ b/dataset/src/jvmTest/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingTensorTest.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.dataset.preprocessor
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Normalizing
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.mean

--- a/examples/src/main/kotlin/examples/dataset/ImagePreprocessing.kt
+++ b/examples/src/main/kotlin/examples/dataset/ImagePreprocessing.kt
@@ -5,7 +5,7 @@
 
 package examples.dataset
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.Dataset
 import org.jetbrains.kotlinx.dl.dataset.OnFlyImageDataset
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/examples/src/main/kotlin/examples/onnx/cv/onnxAdditionalTraining.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/onnxAdditionalTraining.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.pooling.GlobalAvgPool2D
 import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.dataset.preprocessor.onnx
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels

--- a/examples/src/main/kotlin/examples/onnx/posedetection/multipose/multiPoseDetectionMoveNetLightAPI.kt
+++ b/examples/src/main/kotlin/examples/onnx/posedetection/multipose/multiPoseDetectionMoveNetLightAPI.kt
@@ -6,7 +6,7 @@
 package examples.onnx.posedetection.multipose
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/examples/src/main/kotlin/examples/onnx/posedetection/singlepose/PoseDetectionMoveNetLightAPI.kt
+++ b/examples/src/main/kotlin/examples/onnx/posedetection/singlepose/PoseDetectionMoveNetLightAPI.kt
@@ -6,7 +6,7 @@
 package examples.onnx.posedetection.singlepose
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModel.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxInferenceModel.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlinx.dl.api.inference.onnx
 
 import ai.onnxruntime.*
 import ai.onnxruntime.OrtSession.SessionOptions
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.extension.argmax
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders.ExecutionProvider

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/dataset/preprocessor/ONNXModelPreprocessor.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/dataset/preprocessor/ONNXModelPreprocessor.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.dataset.preprocessor
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.PreprocessingPipeline

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/dataset/preprocessor/Transpose.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/dataset/preprocessor/Transpose.kt
@@ -5,8 +5,8 @@
 
 package org.jetbrains.kotlinx.dl.api.dataset.preprocessor
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
-import org.jetbrains.kotlinx.dl.api.core.shape.toTensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.toTensorShape
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.PreprocessingPipeline
 import org.jetbrains.kotlinx.multik.api.mk

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.dataset.preprocessor.Transpose
 import org.jetbrains.kotlinx.dl.api.dataset.preprocessor.transpose
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel

--- a/onnx/src/jvmTest/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingFinalShapeTest.kt
+++ b/onnx/src/jvmTest/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingFinalShapeTest.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.dataset.preprocessor.transpose
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.*

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/GraphTrainableModel.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/GraphTrainableModel.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlinx.dl.api.core.metric.EvaluationResult
 import org.jetbrains.kotlinx.dl.api.core.metric.Metric
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Optimizer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.shape.tail
 import org.jetbrains.kotlinx.dl.api.core.summary.LayerSummary
 import org.jetbrains.kotlinx.dl.api.core.summary.ModelSummary

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlinx.dl.api.core.layer
 
 import org.jetbrains.kotlinx.dl.api.core.GraphTrainableModel
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.shape.tail
 import org.jetbrains.kotlinx.dl.api.core.shape.toTensorShape
 import org.tensorflow.Operand

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.TrainableLayer
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.util.convBiasVarName
 import org.jetbrains.kotlinx.dl.api.core.util.convKernelVarName
 import org.tensorflow.Operand

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlinx.dl.api.core.layer.convolutional
 
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongArray
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.shape.convTransposeOutputLength
 import org.jetbrains.kotlinx.dl.api.core.shape.convTransposePadding
 import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/shape/ShapeFunctions.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/shape/ShapeFunctions.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlinx.dl.api.core.shape
 
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.getDimsOfArray
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/summary/ModelSummary.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/summary/ModelSummary.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.api.core.summary
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * The common information about model.

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/TensorFlowInferenceModel.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/TensorFlowInferenceModel.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlinx.dl.api.inference
 
 import mu.KotlinLogging
 import org.jetbrains.kotlinx.dl.api.core.KGraph
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.shape.contentToString
 import org.jetbrains.kotlinx.dl.api.core.shape.numElements
 import org.jetbrains.kotlinx.dl.api.core.util.*

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/TFModels.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/TFModels.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlinx.dl.api.core.Sequential
 import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.ImageRecognitionModel
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
 import org.jetbrains.kotlinx.dl.api.inference.keras.loadWeights

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/models/FunctionalModelTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/models/FunctionalModelTest.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.pooling.MaxPool2D
 import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Accuracy
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.summary.LayerSummary
 import org.jetbrains.kotlinx.dl.api.core.summary.ModelSummary
 import org.jetbrains.kotlinx.dl.dataset.handler.NUMBER_OF_CLASSES

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/summary/SummaryHelpersTests.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/summary/SummaryHelpersTests.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dl.api.core.summary
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
Due to duplicated package names, it was impossible to build an android
application with both kotlindl-dataset and kotlindl-api modules in the dependencies list.

* Move api.code.TensorShape to dataset.shape.TensorShape

* Change the visibility of internal fields of preprocessing operations on Android to public