### PR TITLE
Extract base classes for task-specific high-level models

### DIFF
--- a/api/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/core/util/prediction.kt
+++ b/api/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/core/util/prediction.kt
@@ -1,13 +1,10 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
 package org.jetbrains.kotlinx.dl.api.core.util
 
-import com.beust.klaxon.JsonArray
-import com.beust.klaxon.JsonObject
-import com.beust.klaxon.Parser
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import java.util.*
 
@@ -34,25 +31,4 @@ internal fun FloatArray.indexOfMaxN(n: Int): List<Int> {
     val predictionsQueue = PriorityQueue<Int>(Comparator.comparing { index -> -this[index] })
     predictionsQueue.addAll(indices)
     return predictionsQueue.take(n)
-}
-
-/** Forms mapping of class label to class name for the ImageNet dataset. */
-public fun loadImageNetClassLabels(): Map<Int, String> {
-    val pathToIndices = "/datasets/vgg/imagenet_class_index.json"
-
-    fun parse(name: String): Any? {
-        val cls = Parser::class.java
-        return cls.getResourceAsStream(name)?.let { inputStream ->
-            return Parser.default().parse(inputStream, Charsets.UTF_8)
-        }
-    }
-
-    val classIndices = parse(pathToIndices) as JsonObject
-
-    val imageNetClassIndices = mutableMapOf<Int, String>()
-
-    for (key in classIndices.keys) {
-        imageNetClassIndices[key.toInt()] = (classIndices[key] as JsonArray<*>)[1].toString()
-    }
-    return imageNetClassIndices
 }

--- a/api/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModelBase.kt
+++ b/api/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModelBase.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.imagerecognition
+
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
+import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
+import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
+
+/**
+ * Base class for image classification models.
+ * @property [internalModel] model used for prediction
+ */
+public abstract class ImageRecognitionModelBase<I>(
+    protected val internalModel: InferenceModel,
+) : InferenceModel by internalModel {
+    /**
+     * Preprocessing operation specific to this model.
+     */
+    protected abstract val preprocessing: Operation<I, Pair<FloatArray, TensorShape>>
+
+    /**
+     * Class labels from the dataset used for training.
+     */
+    protected abstract val classLabels: Map<Int, String>
+
+    /**
+     * Predicts object for the given [image].
+     * Default preprocessing [Operation] is applied to an image.
+     *
+     * @param [image] Input image.
+     * @see preprocessing
+     *
+     * @return The label of the recognized object with the highest probability.
+     */
+    public fun predictObject(image: I): String {
+        val (input, _) = preprocessing.apply(image)
+        return classLabels[internalModel.predict(input)]!!
+    }
+
+    /**
+     * Predicts [topK] objects for the given [image].
+     * Default preprocessing [Operation] is applied to an image.
+     *
+     * @param [image] Input image.
+     * @param [topK] Number of top ranked predictions to return
+     *
+     * @see preprocessing
+     *
+     * @return The list of pairs <label, probability> sorted from the most probable to the lowest probable.
+     */
+    public fun predictTopKObjects(image: I, topK: Int = 5): List<Pair<String, Float>> {
+        val (input, _) = preprocessing.apply(image)
+        return internalModel.predictTopNLabels(input, classLabels, topK)
+    }
+}

--- a/api/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModelBase.kt
+++ b/api/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModelBase.kt
@@ -5,10 +5,10 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.imagerecognition
 
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * Base class for image classification models.

--- a/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModel.kt
+++ b/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModel.kt
@@ -46,23 +46,6 @@ public class ImageRecognitionModel(
         return internalModel.predictTopNLabels(inputData, imageNetClassLabels, topK)
     }
 
-    /**
-     * Predicts [topK] objects for the given [imageFile] with a custom [DataLoader] provided.
-     *
-     * @param [imageFile] Input image [File].
-     * @param [dataLoader] custom [DataLoader] instance
-     * @param [topK] Number of top ranked predictions to return
-     *
-     * @return The list of pairs <label, probability> sorted from the most probable to the lowest probable.
-     */
-    public fun predictTopKObjects(imageFile: File,
-                                  dataLoader: DataLoader<File>,
-                                  topK: Int = 5
-    ): List<Pair<String, Float>> {
-        val (inputData, _) = dataLoader.load(imageFile)
-        return internalModel.predictTopNLabels(inputData, imageNetClassLabels, topK)
-    }
-
     private fun preprocessData(imageFile: File): FloatArray {
         val (width, height) = if (modelType.channelsFirst)
             Pair(internalModel.inputDimensions[1], internalModel.inputDimensions[2])
@@ -93,19 +76,6 @@ public class ImageRecognitionModel(
      */
     public fun predictObject(imageFile: File): String {
         val inputData = preprocessData(imageFile)
-        return imageNetClassLabels[internalModel.predict(inputData)]!!
-    }
-
-    /**
-     * Predicts object for the given [imageFile] with a custom [DataLoader] provided.
-     *
-     * @param [imageFile] Input image [File].
-     * @param [dataLoader] custom [DataLoader] instance
-     *
-     * @return The label of the recognized object with the highest probability.
-     */
-    public fun predictObject(imageFile: File, dataLoader: DataLoader<File>): String {
-        val (inputData, _) = dataLoader.load(imageFile)
         return imageNetClassLabels[internalModel.predict(inputData)]!!
     }
 

--- a/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModel.kt
+++ b/api/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/imagerecognition/ImageRecognitionModel.kt
@@ -5,20 +5,23 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.imagerecognition
 
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.keras.loaders.ModelType
 import org.jetbrains.kotlinx.dl.dataset.DataLoader
+import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
+import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.call
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
-import org.jetbrains.kotlinx.dl.dataset.preprocessor.*
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.InterpolationType
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.convert
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.resize
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.toFloatArray
 import java.awt.image.BufferedImage
 import java.io.File
+import java.io.IOException
 
 /**
  * The light-weight API for solving Image Recognition task with one of the Model Hub models trained on ImageNet dataset.
@@ -30,39 +33,68 @@ public class ImageRecognitionModel(
     /** Class labels for ImageNet dataset. */
     public val imageNetClassLabels: Map<Int, String> = loadImageNetClassLabels()
 
+    private val preprocessing: Operation<BufferedImage, Pair<FloatArray, TensorShape>>
+        get() {
+            val (width, height) = if (modelType.channelsFirst)
+                Pair(internalModel.inputDimensions[1], internalModel.inputDimensions[2])
+            else
+                Pair(internalModel.inputDimensions[0], internalModel.inputDimensions[1])
+
+            return pipeline<BufferedImage>()
+                .resize {
+                    outputHeight = height.toInt()
+                    outputWidth = width.toInt()
+                    interpolation = InterpolationType.BILINEAR
+                }
+                .convert { colorMode = modelType.inputColorMode }
+                .toFloatArray {}
+                .call(modelType.preprocessor)
+        }
+
+    /**
+     * Predicts [topK] objects for the given [image].
+     * Default preprocessing [Operation] is applied to an image.
+     *
+     * @param [image] Input image.
+     * @param [topK] Number of top ranked predictions to return
+     *
+     * @see preprocessing
+     *
+     * @return The list of pairs <label, probability> sorted from the most probable to the lowest probable.
+     */
+    public fun predictTopKObjects(image: BufferedImage, topK: Int): List<Pair<String, Float>> {
+        val inputData = preprocessing.apply(image).first
+        return internalModel.predictTopNLabels(inputData, imageNetClassLabels, topK)
+    }
+
     /**
      * Predicts [topK] objects for the given [imageFile].
-     * Default [DataLoader] is used to load and prepare image.
+     * Default preprocessing [Operation] is applied to an image.
      *
      * @param [imageFile] Input image [File].
      * @param [topK] Number of top ranked predictions to return
      *
-     * @see preprocessData
+     * @see preprocessing
      *
      * @return The list of pairs <label, probability> sorted from the most probable to the lowest probable.
      */
-    public fun predictTopKObjects(imageFile: File, topK: Int = 5): List<Pair<String, Float>> {
-        val inputData = preprocessData(imageFile)
-        return internalModel.predictTopNLabels(inputData, imageNetClassLabels, topK)
+    @Throws(IOException::class)
+    public fun predictTopKObjects(imageFile: File, topK: Int): List<Pair<String, Float>> {
+        return predictTopKObjects(ImageConverter.toBufferedImage(imageFile), topK)
     }
 
-    private fun preprocessData(imageFile: File): FloatArray {
-        val (width, height) = if (modelType.channelsFirst)
-            Pair(internalModel.inputDimensions[1], internalModel.inputDimensions[2])
-        else
-            Pair(internalModel.inputDimensions[0], internalModel.inputDimensions[1])
-
-        val preprocessing = pipeline<BufferedImage>()
-            .resize {
-                outputHeight = height.toInt()
-                outputWidth = width.toInt()
-                interpolation = InterpolationType.BILINEAR
-            }
-            .convert { colorMode = modelType.inputColorMode }
-            .toFloatArray {}
-            .call(modelType.preprocessor)
-
-        return preprocessing.fileLoader().load(imageFile).first
+    /**
+     * Predicts object for the given [image].
+     * Default preprocessing [Operation] is applied to an image.
+     *
+     * @param [image] Input image.
+     * @see preprocessing
+     *
+     * @return The label of the recognized object with the highest probability.
+     */
+    public fun predictObject(image: BufferedImage): String {
+        val inputData = preprocessing.apply(image).first
+        return imageNetClassLabels[internalModel.predict(inputData)]!!
     }
 
     /**
@@ -70,13 +102,13 @@ public class ImageRecognitionModel(
      * Default preprocessing [Operation] is applied to an image.
      *
      * @param [imageFile] Input image [File].
-     * @see preprocessData
+     * @see preprocessing
      *
      * @return The label of the recognized object with the highest probability.
      */
+    @Throws(IOException::class)
     public fun predictObject(imageFile: File): String {
-        val inputData = preprocessData(imageFile)
-        return imageNetClassLabels[internalModel.predict(inputData)]!!
+        return predictObject(ImageConverter.toBufferedImage(imageFile))
     }
 
     override fun copy(

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageConverter.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/image/ImageConverter.kt
@@ -108,6 +108,16 @@ public object ImageConverter {
         return ImageIO.read(inputStream)
     }
 
+    /**
+     * Returns [BufferedImage] extracted from [file].
+     *
+     * @param [file] source of the image
+     */
+    @Throws(IOException::class)
+    public fun toBufferedImage(file: File): BufferedImage {
+        return file.inputStream().use { inputStream -> toBufferedImage(inputStream) }
+    }
+
     private fun imageToFloatArray(image: BufferedImage, colorMode: ColorMode?): FloatArray {
         if (colorMode != null && image.colorMode() != colorMode) {
             return imageToFloatArray(Convert(colorMode = colorMode).apply(image))

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
@@ -5,10 +5,10 @@
 
 package org.jetbrains.kotlinx.dl.dataset.preprocessor
 
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.dataset.DataLoader
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.InputStream

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessor/PreprocessingDataLoader.kt
@@ -25,10 +25,7 @@ private class PreprocessingFileDataLoader(
             if (dataSource.isDirectory) "File '$dataSource' is a directory."
             else "File '$dataSource' is not a normal file."
         }
-
-        val image = dataSource.inputStream().use { inputStream -> ImageConverter.toBufferedImage(inputStream) }
-
-        return preprocessing.apply(image)
+        return preprocessing.apply(ImageConverter.toBufferedImage(dataSource))
     }
 }
 

--- a/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNet4Lite.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNet4Lite.kt
@@ -6,8 +6,8 @@
 package examples.onnx.cv.efficicentnet
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNet4Lite.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNet4Lite.kt
@@ -6,7 +6,7 @@
 package examples.onnx.cv.efficicentnet
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels

--- a/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNetB0.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNetB0.kt
@@ -6,8 +6,8 @@
 package examples.onnx.cv.efficicentnet
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNetB0.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNetB0.kt
@@ -6,7 +6,7 @@
 package examples.onnx.cv.efficicentnet
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels

--- a/examples/src/main/kotlin/examples/onnx/cv/onnxPredictionRunner.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/onnxPredictionRunner.kt
@@ -6,7 +6,7 @@
 package examples.onnx.cv
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels

--- a/examples/src/main/kotlin/examples/onnx/cv/onnxPredictionRunner.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/onnxPredictionRunner.kt
@@ -6,12 +6,11 @@
 package examples.onnx.cv
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
-import org.jetbrains.kotlinx.dl.dataset.preprocessor.fileLoader
 import java.io.File
 
 fun runONNXImageRecognitionPrediction(

--- a/examples/src/main/kotlin/examples/onnx/cv/predictionRunner.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/predictionRunner.kt
@@ -6,8 +6,8 @@
 package examples.onnx.cv
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel

--- a/examples/src/main/kotlin/examples/onnx/cv/predictionRunner.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/predictionRunner.kt
@@ -6,7 +6,7 @@
 package examples.onnx.cv
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels

--- a/examples/src/main/kotlin/examples/onnx/cv/resnet/notop/ResNet50.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/resnet/notop/ResNet50.kt
@@ -6,8 +6,8 @@
 package examples.onnx.cv.resnet.notop
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/examples/src/main/kotlin/examples/onnx/cv/resnet/notop/ResNet50.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/resnet/notop/ResNet50.kt
@@ -6,7 +6,7 @@
 package examples.onnx.cv.resnet.notop
 
 import examples.transferlearning.getFileFromResource
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTopNLabels
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet121.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet121.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.keras.*
 import org.jetbrains.kotlinx.dl.api.inference.keras.loaders.TFModelHub

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet121.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet121.kt
@@ -11,8 +11,8 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.keras.*
 import org.jetbrains.kotlinx.dl.api.inference.keras.loaders.TFModelHub
 import org.jetbrains.kotlinx.dl.api.inference.keras.loaders.TFModels

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_2_VGG16_loading_weights_from_txt_format.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_2_VGG16_loading_weights_from_txt_format.kt
@@ -11,9 +11,9 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.call
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_2_VGG16_loading_weights_from_txt_format.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_2_VGG16_loading_weights_from_txt_format.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_3_VGG16_loading_weights_from_old_keras_weight_format.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_3_VGG16_loading_weights_from_old_keras_weight_format.kt
@@ -12,9 +12,9 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.keras.*
 import org.jetbrains.kotlinx.dl.dataset.OnHeapDataset
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_3_VGG16_loading_weights_from_old_keras_weight_format.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_3_VGG16_loading_weights_from_old_keras_weight_format.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
 import org.jetbrains.kotlinx.dl.api.inference.keras.*

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_4_VGG16_prediction_load_model_from_disk.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_4_VGG16_prediction_load_model_from_disk.kt
@@ -12,9 +12,9 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.keras.loadWeights
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.call

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_4_VGG16_prediction_load_model_from_disk.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_4_VGG16_prediction_load_model_from_disk.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
 import org.jetbrains.kotlinx.dl.api.inference.keras.loadWeights

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_2_VGG19_prediction_from_disk.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_2_VGG19_prediction_from_disk.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -12,7 +12,7 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
 import org.jetbrains.kotlinx.dl.api.inference.keras.loadWeights

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_2_VGG19_prediction_from_disk.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_2_VGG19_prediction_from_disk.kt
@@ -12,9 +12,9 @@ import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
 import org.jetbrains.kotlinx.dl.api.core.summary.logSummary
-import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.core.util.predictTop5Labels
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.keras.loadWeights
 import org.jetbrains.kotlinx.dl.dataset.OnHeapDataset
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode

--- a/examples/src/test/kotlin/examples/onnx/objectdetection/ObjectDetectionTestSuite.kt
+++ b/examples/src/test/kotlin/examples/onnx/objectdetection/ObjectDetectionTestSuite.kt
@@ -152,8 +152,7 @@ fun efficientDetLightAPIInference(modelType: ONNXModels.ObjectDetection<OnnxInfe
 
     model.use { detectionModel ->
         val imageFile = getFileFromResource("datasets/detection/image4.jpg")
-        val detectedObjects =
-            detectionModel.detectObjects(imageFile = imageFile)
+        val detectedObjects = detectionModel.detectObjects(imageFile = imageFile, topK = 0)
 
         assertEquals(numberOfDetectedObjects, detectedObjects.size)
     }

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxHighLevelModel.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxHighLevelModel.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
  * @param [I] input type
  * @param [R] output type
  */
-public interface OnnxPreTrainedModel<I, R> {
+public interface OnnxHighLevelModel<I, R> {
     /**
      * Model used to make predictions.
      */

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxPreTrainedModel.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxPreTrainedModel.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
  * @param [I] input type
  * @param [R] output type
  */
-public abstract interface OnnxPreTrainedModel<I, R> {
+public interface OnnxPreTrainedModel<I, R> {
     /**
      * Model used to make predictions.
      */

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxPreTrainedModel.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxPreTrainedModel.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.onnx
+
+import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
+
+/**
+ * Base class for pre-trained high-level onnx models.
+ *
+ * @param [I] input type
+ * @param [R] output type
+ */
+public abstract interface OnnxPreTrainedModel<I, R> {
+    /**
+     * Model used to make predictions.
+     */
+    public val internalModel: OnnxInferenceModel
+
+    /**
+     * Preprocessing operation specific to this model.
+     */
+    public val preprocessing: Operation<I, Pair<FloatArray, TensorShape>>
+
+    /**
+     * Converts raw model output to the result.
+     */
+    public fun convert(output: Map<String, Any>): R
+
+    /**
+     * Makes prediction on the given [input].
+     */
+    public fun predict(input: I): R {
+        val preprocessedInput = preprocessing.apply(input)
+        val output = internalModel.predictRaw(preprocessedInput.first)
+        return convert(output)
+    }
+}

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
@@ -5,12 +5,8 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.facealignment
 
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
-import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.facealignment.Landmark
-import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
-import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 
 /**
  * Base class for face alignment models.

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
@@ -6,12 +6,12 @@
 package org.jetbrains.kotlinx.dl.api.inference.onnx.facealignment
 
 import org.jetbrains.kotlinx.dl.api.inference.facealignment.Landmark
-import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
 
 /**
  * Base class for face alignment models.
  */
-public abstract class FaceAlignmentModelBase<I> : OnnxPreTrainedModel<I, List<Landmark>> {
+public abstract class FaceAlignmentModelBase<I> : OnnxHighLevelModel<I, List<Landmark>> {
     /**
      * Name of the output tensor.
      */

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.onnx.facealignment
+
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.facealignment.Landmark
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
+import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
+
+/**
+ * Base class for face alignment models.
+ */
+public abstract class FaceAlignmentModelBase<I> : OnnxPreTrainedModel<I, List<Landmark>> {
+    /**
+     * Name of the output tensor.
+     */
+    protected abstract val outputName: String
+
+    override fun convert(output: Map<String, Any>): List<Landmark> {
+        val landMarks = mutableListOf<Landmark>()
+        val floats = (output[outputName] as Array<*>)[0] as FloatArray
+        for (i in floats.indices step 2) {
+            landMarks.add(Landmark(floats[i], floats[i + 1]))
+        }
+
+        return landMarks
+    }
+
+    /**
+     * Detects [Landmark] objects on the given [image].
+     */
+    public fun detectLandmarks(image: I): List<Landmark> = predict(image)
+}

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/ObjectDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/ObjectDetectionModelBase.kt
@@ -6,12 +6,12 @@
 package org.jetbrains.kotlinx.dl.api.inference.onnx.objectdetection
 
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
-import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
 
 /**
  * Base class for object detection models.
  */
-public abstract class ObjectDetectionModelBase<I> : OnnxPreTrainedModel<I, List<DetectedObject>> {
+public abstract class ObjectDetectionModelBase<I> : OnnxHighLevelModel<I, List<DetectedObject>> {
     /**
      * Class labels from the dataset used for training.
      */

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/ObjectDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/ObjectDetectionModelBase.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.onnx.objectdetection
+
+import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
+
+/**
+ * Base class for object detection models.
+ */
+public abstract class ObjectDetectionModelBase<I> : OnnxPreTrainedModel<I, List<DetectedObject>> {
+    /**
+     * Class labels from the dataset used for training.
+     */
+    protected abstract val classLabels: Map<Int, String>
+
+    /**
+     * Returns the detected object for the given image sorted by the score.
+     *
+     * @param [image] Input image.
+     * @param [topK] The number of the detected objects with the highest score to be returned.
+     * @return List of [DetectedObject] sorted by score.
+     */
+    public fun detectObjects(image: I, topK: Int = 5): List<DetectedObject> {
+        val objects = predict(image).sortedByDescending { it.probability }
+        if (topK > 0) {
+            return objects.take(topK)
+        }
+        return objects
+    }
+}
+
+/**
+ * Base class for object detection models based on EfficientDet architecture.
+ */
+public abstract class EfficientDetObjectDetectionModelBase<I> : ObjectDetectionModelBase<I>() {
+
+    override fun convert(output: Map<String, Any>): List<DetectedObject> {
+        val foundObjects = mutableListOf<DetectedObject>()
+        val items = (output[OUTPUT_NAME] as Array<Array<FloatArray>>)[0]
+
+        for (i in items.indices) {
+            val probability = items[i][5]
+            if (probability != 0.0f) {
+                val detectedObject = DetectedObject(
+                    classLabel = classLabels[items[i][6].toInt()]!!,
+                    probability = probability,
+                    // left, bot, right, top
+                    xMin = minOf(items[i][2] / internalModel.inputDimensions[1], 1.0f),
+                    yMax = minOf(items[i][3] / internalModel.inputDimensions[0], 1.0f),
+                    xMax = minOf(items[i][4] / internalModel.inputDimensions[1], 1.0f),
+                    yMin = minOf(items[i][1] / internalModel.inputDimensions[0], 1.0f)
+                )
+                foundObjects.add(detectedObject)
+            }
+        }
+        return foundObjects
+    }
+
+    private companion object {
+        private const val OUTPUT_NAME = "detections:0"
+    }
+}
+
+/**
+ * Base class for object detection model based on SSD-MobilNet architecture.
+ */
+public abstract class SSDMobileNetObjectDetectionModelBase<I> : ObjectDetectionModelBase<I>() {
+
+    override fun convert(output: Map<String, Any>): List<DetectedObject> {
+        val foundObjects = mutableListOf<DetectedObject>()
+        val boxes = (output[OUTPUT_BOXES] as Array<Array<FloatArray>>)[0]
+        val classIndices = (output[OUTPUT_CLASSES] as Array<FloatArray>)[0]
+        val probabilities = (output[OUTPUT_SCORES] as Array<FloatArray>)[0]
+        val numberOfFoundObjects = (output[OUTPUT_NUMBER_OF_DETECTIONS] as FloatArray)[0].toInt()
+
+        for (i in 0 until numberOfFoundObjects) {
+            val detectedObject = DetectedObject(
+                classLabel = classLabels[classIndices[i].toInt()]!!,
+                probability = probabilities[i],
+                // top, left, bottom, right
+                yMin = boxes[i][0],
+                xMin = boxes[i][1],
+                yMax = boxes[i][2],
+                xMax = boxes[i][3]
+            )
+            foundObjects.add(detectedObject)
+        }
+        return foundObjects
+    }
+
+    private companion object {
+        private const val OUTPUT_BOXES = "detection_boxes:0"
+        private const val OUTPUT_CLASSES = "detection_classes:0"
+        private const val OUTPUT_SCORES = "detection_scores:0"
+        private const val OUTPUT_NUMBER_OF_DETECTIONS = "num_detections:0"
+    }
+}
+
+/**
+ * Base class for object detection model based on SSD architecture.
+ */
+public abstract class SSDObjectDetectionModelBase<I> : ObjectDetectionModelBase<I>() {
+
+    override fun convert(output: Map<String, Any>): List<DetectedObject> {
+        val boxes = (output[OUTPUT_BOXES] as Array<Array<FloatArray>>)[0]
+        val classIndices = (output[OUTPUT_LABELS] as Array<LongArray>)[0]
+        val probabilities = (output[OUTPUT_SCORES] as Array<FloatArray>)[0]
+        val numberOfFoundObjects = boxes.size
+
+        val foundObjects = mutableListOf<DetectedObject>()
+        for (i in 0 until numberOfFoundObjects) {
+            val detectedObject = DetectedObject(
+                classLabel = classLabels[classIndices[i].toInt()]!!,
+                probability = probabilities[i],
+                // left, bot, right, top
+                xMin = boxes[i][0],
+                yMin = boxes[i][1],
+                xMax = boxes[i][2],
+                yMax = boxes[i][3]
+            )
+            foundObjects.add(detectedObject)
+        }
+        return foundObjects
+    }
+
+    private companion object {
+        private const val OUTPUT_BOXES = "bboxes"
+        private const val OUTPUT_LABELS = "labels"
+        private const val OUTPUT_SCORES = "scores"
+    }
+}

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
+
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.facealignment.Landmark
+import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
+import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
+import org.jetbrains.kotlinx.dl.api.inference.posedetection.MultiPoseDetectionResult
+import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
+import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
+
+/**
+ * Base class for pose detection models for detecting multiple poses per image.
+ */
+public abstract class MultiPoseDetectionModelBase<I> : OnnxPreTrainedModel<I, MultiPoseDetectionResult> {
+    /**
+     * Name of the output tensor.
+     */
+    protected abstract val outputName: String
+
+    /**
+     * Dictionary that maps from joint names to keypoint indices.
+     */
+    protected abstract val keyPointsLabels: Map<Int, String>
+
+    /**
+     * Pairs of points which define body edges.
+     */
+    protected abstract val edgeKeyPoints: List<Pair<Int, Int>>
+
+    override fun convert(output: Map<String, Any>): MultiPoseDetectionResult {
+        val rawPoseLandMarks = (output[outputName] as Array<Array<FloatArray>>)[0]
+
+        val poses = rawPoseLandMarks.map { floats ->
+            val foundPoseLandmarks = mutableListOf<PoseLandmark>()
+
+            for (keyPointIdx in 0..16) {
+                val poseLandmark = PoseLandmark(
+                    poseLandmarkLabel = keyPointsLabels[keyPointIdx]!!,
+                    x = floats[3 * keyPointIdx + 1],
+                    y = floats[3 * keyPointIdx],
+                    probability = floats[3 * keyPointIdx + 2]
+                )
+                foundPoseLandmarks.add(poseLandmark)
+            }
+
+            // [ymin, xmin, ymax, xmax, score]
+            val detectedObject = DetectedObject(
+                classLabel = CLASS_LABEL,
+                probability = floats[55],
+                yMin = floats[53],
+                xMin = floats[52],
+                yMax = floats[51],
+                xMax = floats[54]
+            )
+
+            val foundPoseEdges = buildPoseEdges(foundPoseLandmarks, edgeKeyPoints)
+            val detectedPose = DetectedPose(foundPoseLandmarks, foundPoseEdges)
+
+            detectedObject to detectedPose
+        }
+
+        return MultiPoseDetectionResult(poses)
+    }
+
+    /**
+     * Detects poses for the given [image] with the given [confidence].
+     * @param [confidence] confidence value to use
+     */
+    public fun detectPoses(image: I, confidence: Float = 0.1f): MultiPoseDetectionResult {
+        val result = predict(image)
+        val filteredPoses = result.multiplePoses.filter { (detectedObject, _) ->
+            detectedObject.probability > confidence
+        }
+        return MultiPoseDetectionResult(filteredPoses)
+    }
+
+    private companion object {
+        private const val CLASS_LABEL = "person"
+    }
+}

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
 
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
-import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.MultiPoseDetectionResult
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
@@ -14,7 +14,7 @@ import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
 /**
  * Base class for pose detection models for detecting multiple poses per image.
  */
-public abstract class MultiPoseDetectionModelBase<I> : OnnxPreTrainedModel<I, MultiPoseDetectionResult> {
+public abstract class MultiPoseDetectionModelBase<I> : OnnxHighLevelModel<I, MultiPoseDetectionResult> {
     /**
      * Name of the output tensor.
      */

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
@@ -5,16 +5,11 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
 
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
-import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
-import org.jetbrains.kotlinx.dl.api.inference.facealignment.Landmark
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
-import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.MultiPoseDetectionResult
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
-import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 
 /**
  * Base class for pose detection models for detecting multiple poses per image.

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModelBase.kt
@@ -5,15 +5,10 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
 
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
-import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
-import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
-import org.jetbrains.kotlinx.dl.api.inference.posedetection.MultiPoseDetectionResult
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseEdge
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
-import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import kotlin.math.min
 
 /**

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModelBase.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
 
-import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseEdge
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
@@ -14,7 +14,7 @@ import kotlin.math.min
 /**
  * Base class for pose detection models for detecting a single pose per image.
  */
-public abstract class SinglePoseDetectionModelBase<I> : OnnxPreTrainedModel<I, DetectedPose> {
+public abstract class SinglePoseDetectionModelBase<I> : OnnxHighLevelModel<I, DetectedPose> {
 
     /**
      * Name of the output tensor.

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModelBase.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
+
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxPreTrainedModel
+import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
+import org.jetbrains.kotlinx.dl.api.inference.posedetection.MultiPoseDetectionResult
+import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseEdge
+import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
+import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
+import kotlin.math.min
+
+/**
+ * Base class for pose detection models for detecting a single pose per image.
+ */
+public abstract class SinglePoseDetectionModelBase<I> : OnnxPreTrainedModel<I, DetectedPose> {
+
+    /**
+     * Name of the output tensor.
+     */
+    protected abstract val outputName: String
+
+    /**
+     * Dictionary that maps from joint names to keypoint indices.
+     */
+    protected abstract val keyPointsLabels: Map<Int, String>
+
+    /**
+     * Pairs of points which define body edges.
+     */
+    protected abstract val edgeKeyPoints: List<Pair<Int, Int>>
+
+    override fun convert(output: Map<String, Any>): DetectedPose {
+        val rawPoseLandMarks = (output[outputName] as Array<Array<Array<FloatArray>>>)[0][0]
+
+        val foundPoseLandmarks = mutableListOf<PoseLandmark>()
+        for (i in rawPoseLandMarks.indices) {
+            val poseLandmark = PoseLandmark(
+                poseLandmarkLabel = keyPointsLabels[i]!!,
+                x = rawPoseLandMarks[i][1],
+                y = rawPoseLandMarks[i][0],
+                probability = rawPoseLandMarks[i][2]
+            )
+            foundPoseLandmarks.add(i, poseLandmark)
+        }
+
+        val foundPoseEdges = buildPoseEdges(foundPoseLandmarks, edgeKeyPoints)
+
+        return DetectedPose(foundPoseLandmarks, foundPoseEdges)
+    }
+
+    /**
+     * Detects a pose for the given [image].
+     * @param [image] input image.
+     */
+    public fun detectPose(image: I): DetectedPose = predict(image)
+}
+
+internal fun buildPoseEdges(foundPoseLandmarks: List<PoseLandmark>, edgeKeyPoints: List<Pair<Int, Int>>): List<PoseEdge> {
+    val foundPoseEdges = mutableListOf<PoseEdge>()
+    edgeKeyPoints.forEach {
+        val startPoint = foundPoseLandmarks[it.first]
+        val endPoint = foundPoseLandmarks[it.second]
+        foundPoseEdges.add(
+            PoseEdge(
+                poseEdgeLabel = startPoint.poseLandmarkLabel + "_" + endPoint.poseLandmarkLabel,
+                probability = min(startPoint.probability, endPoint.probability),
+                start = startPoint,
+                end = endPoint
+            )
+        )
+    }
+    return foundPoseEdges
+}

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx
 
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.dataset.preprocessor.Transpose
 import org.jetbrains.kotlinx.dl.api.dataset.preprocessor.transpose
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
@@ -23,6 +22,7 @@ import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.call
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /** Models in the ONNX format and running via ONNX Runtime. */
 public object ONNXModels {

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
@@ -40,7 +40,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 18 layers with ResNetv1 architecture.
          *
@@ -62,7 +62,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 34 layers with ResNetv1 architecture.
          *
@@ -84,7 +84,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 50 layers with ResNetv1 architecture.
          *
@@ -107,7 +107,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 101 layers with ResNetv1 architecture.
          *
@@ -130,7 +130,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 152 layers with ResNetv1 architecture.
          *
@@ -153,7 +153,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 18 layers with ResNetv2 architecture.
          *
@@ -176,7 +176,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 34 layers with ResNetv2 architecture.
          *
@@ -199,7 +199,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 50 layers with ResNetv2 architecture.
          *
@@ -222,7 +222,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 101 layers with ResNetv2 architecture.
          *
@@ -245,7 +245,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 152 layers with ResNetv2 architecture.
          *
@@ -268,7 +268,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * EfficientNet-Lite 4 is the largest variant and most accurate of the set of EfficientNet-Lite model.
          * It is an integer-only quantized model that produces the highest accuracy of all of the EfficientNet models.
@@ -291,7 +291,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 50 layers with ResNetv1 architecture.
          *
@@ -318,7 +318,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 50 layers with ResNetv1 architecture.
          *
@@ -341,7 +341,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the EfficientNetB0 architecture.
          *
@@ -366,7 +366,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the EfficientNetB1 architecture.
          *
@@ -391,7 +391,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the EfficientNetB2 architecture.
          *
@@ -416,7 +416,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the EfficientNetB3 architecture.
          *
@@ -441,7 +441,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the EfficientNetB4 architecture.
          *
@@ -466,7 +466,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the EfficientNetB5 architecture.
          *
@@ -491,7 +491,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the EfficientNetB6 architecture.
          *
@@ -516,7 +516,7 @@ public object ONNXModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the EfficientNetB7 architecture.
          *

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/Fan2D106FaceAlignmentModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/Fan2D106FaceAlignmentModel.kt
@@ -5,9 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.facealignment
 
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
-import org.jetbrains.kotlinx.dl.api.inference.onnx.facealignment.FaceAlignmentModelBase
 import org.jetbrains.kotlinx.dl.api.inference.facealignment.Landmark
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
@@ -16,10 +14,10 @@ import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.call
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
-import org.jetbrains.kotlinx.dl.dataset.preprocessor.fileLoader
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.convert
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.resize
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.toFloatArray
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.IOException

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/EfficientDetObjectDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/EfficientDetObjectDetectionModel.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.objectdetection
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
@@ -18,6 +17,7 @@ import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.convert
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.resize
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.toFloatArray
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.IOException
@@ -34,8 +34,10 @@ private const val OUTPUT_NAME = "detections:0"
  *
  * @since 0.4
  */
-public class EfficientDetObjectDetectionModel(private val internalModel: OnnxInferenceModel) : InferenceModel by internalModel {
-    private val preprocessing: Operation<BufferedImage, Pair<FloatArray, TensorShape>>
+public class EfficientDetObjectDetectionModel(override val internalModel: OnnxInferenceModel) :
+    EfficientDetObjectDetectionModelBase<BufferedImage>(), InferenceModel by internalModel {
+
+    override val preprocessing: Operation<BufferedImage, Pair<FloatArray, TensorShape>>
         get() = pipeline<BufferedImage>()
             .resize {
                 outputHeight = inputDimensions[0].toInt()
@@ -44,56 +46,14 @@ public class EfficientDetObjectDetectionModel(private val internalModel: OnnxInf
             // the channels of input of EfficientDet models should be in RGB order
             // model is quite sensitive for this
             .convert { colorMode = ColorMode.RGB }
-            .toFloatArray {  }
+            .toFloatArray { }
+    override val classLabels: Map<Int, String> = cocoCategories
 
     /**
      * Constructs the object detection model from a given path.
      * @param [pathToModel] path to model
      */
-    public constructor(pathToModel: String): this(OnnxInferenceModel(pathToModel))
-
-    /**
-     * Returns the detected object for the given image file sorted by the score.
-     *
-     * @param [inputData] Preprocessed data from the image file.
-     * @return List of [DetectedObject] sorted by score.
-     */
-    public fun detectObjects(inputData: FloatArray): List<DetectedObject> {
-        val rawPrediction = internalModel.predictRaw(inputData)
-        val foundObjects = mutableListOf<DetectedObject>()
-        val items = (rawPrediction[OUTPUT_NAME] as Array<Array<FloatArray>>)[0]
-
-        for (i in items.indices) {
-            val probability = items[i][5]
-            if (probability != 0.0f) {
-                val detectedObject = DetectedObject(
-                    classLabel = cocoCategories[items[i][6].toInt()]!!,
-                    probability = probability,
-                    // left, bot, right, top
-                    xMin = minOf(items[i][2] / inputDimensions[1], 1.0f),
-                    yMax = minOf(items[i][3] / inputDimensions[0], 1.0f),
-                    xMax = minOf(items[i][4] / inputDimensions[1], 1.0f),
-                    yMin = minOf(items[i][1] / inputDimensions[0], 1.0f)
-                )
-                foundObjects.add(detectedObject)
-            }
-        }
-
-        foundObjects.sortByDescending { it.probability }
-        return foundObjects
-    }
-
-    /**
-     * Returns the detected object for the given image sorted by the score.
-     *
-     * NOTE: this method includes the EfficientDet - related preprocessing.
-     *
-     * @param [image] Input image.
-     * @return List of [DetectedObject] sorted by score.
-     */
-    public fun detectObjects(image: BufferedImage): List<DetectedObject> {
-        return detectObjects(preprocessing.apply(image).first)
-    }
+    public constructor(pathToModel: String) : this(OnnxInferenceModel(pathToModel))
 
     /**
      * Returns the detected object for the given image file sorted by the score.
@@ -101,11 +61,12 @@ public class EfficientDetObjectDetectionModel(private val internalModel: OnnxInf
      * NOTE: this method includes the EfficientDet - related preprocessing.
      *
      * @param [imageFile] File, should be an image.
+     * @param [topK] The number of the detected objects with the highest score to be returned.
      * @return List of [DetectedObject] sorted by score.
      */
     @Throws(IOException::class)
-    public fun detectObjects(imageFile: File): List<DetectedObject> {
-        return detectObjects(ImageConverter.toBufferedImage(imageFile))
+    public fun detectObjects(imageFile: File, topK: Int = 5): List<DetectedObject> {
+        return detectObjects(ImageConverter.toBufferedImage(imageFile), topK)
     }
 
     override fun copy(

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/EfficientDetObjectDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/EfficientDetObjectDetectionModel.kt
@@ -22,8 +22,6 @@ import java.awt.image.BufferedImage
 import java.io.File
 import java.io.IOException
 
-private const val OUTPUT_NAME = "detections:0"
-
 /**
  * Special model class for detection objects on images
  * with built-in preprocessing and post-processing.

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDMobileNetV1ObjectDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDMobileNetV1ObjectDetectionModel.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.objectdetection
 
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
@@ -19,14 +18,10 @@ import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.convert
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.resize
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.toFloatArray
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.IOException
-
-private const val OUTPUT_BOXES = "detection_boxes:0"
-private const val OUTPUT_CLASSES = "detection_classes:0"
-private const val OUTPUT_SCORES = "detection_scores:0"
-private const val OUTPUT_NUMBER_OF_DETECTIONS = "num_detections:0"
 
 /**
  * Special model class for detection objects on images
@@ -56,7 +51,7 @@ public class SSDMobileNetV1ObjectDetectionModel(override val internalModel: Onnx
      * Constructs the object detection model from a given path.
      * @param [pathToModel] path to model
      */
-    public constructor(pathToModel: String): this(OnnxInferenceModel(pathToModel))
+    public constructor(pathToModel: String) : this(OnnxInferenceModel(pathToModel))
 
     /**
      * Returns the top N detected object for the given image file sorted by the score.

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDMobileNetV1ObjectDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDMobileNetV1ObjectDetectionModel.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.objectdetection
 
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
@@ -38,8 +38,10 @@ private const val OUTPUT_NUMBER_OF_DETECTIONS = "num_detections:0"
  *
  * @since 0.4
  */
-public class SSDMobileNetV1ObjectDetectionModel(private val internalModel: OnnxInferenceModel) : InferenceModel by internalModel {
-    private val preprocessing: Operation<BufferedImage, Pair<FloatArray, TensorShape>>
+public class SSDMobileNetV1ObjectDetectionModel(override val internalModel: OnnxInferenceModel) :
+    SSDMobileNetObjectDetectionModelBase<BufferedImage>(), InferenceModel by internalModel {
+
+    override val preprocessing: Operation<BufferedImage, Pair<FloatArray, TensorShape>>
         get() = pipeline<BufferedImage>()
             .resize {
                 outputHeight = inputDimensions[0].toInt()
@@ -48,65 +50,13 @@ public class SSDMobileNetV1ObjectDetectionModel(private val internalModel: OnnxI
             .convert { colorMode = ColorMode.RGB }
             .toFloatArray { }
             .call(ONNXModels.ObjectDetection.SSDMobileNetV1.preprocessor)
+    override val classLabels: Map<Int, String> = cocoCategories
 
     /**
      * Constructs the object detection model from a given path.
      * @param [pathToModel] path to model
      */
     public constructor(pathToModel: String): this(OnnxInferenceModel(pathToModel))
-
-    /**
-     * Returns the top N detected object for the given image file sorted by the score.
-     *
-     * NOTE: this method doesn't include the SSD - related preprocessing.
-     *
-     * @param [inputData] Preprocessed data from the image file.
-     * @param [topK] The number of the detected objects with the highest score to be returned.
-     * @return List of [DetectedObject] sorted by score.
-     */
-    public fun detectObjects(inputData: FloatArray, topK: Int = 5): List<DetectedObject> {
-        val rawPrediction = internalModel.predictRaw(inputData)
-
-        val foundObjects = mutableListOf<DetectedObject>()
-        val boxes = (rawPrediction[OUTPUT_BOXES] as Array<Array<FloatArray>>)[0]
-        val classIndices = (rawPrediction[OUTPUT_CLASSES] as Array<FloatArray>)[0]
-        val probabilities = (rawPrediction[OUTPUT_SCORES] as Array<FloatArray>)[0]
-        val numberOfFoundObjects = (rawPrediction[OUTPUT_NUMBER_OF_DETECTIONS] as FloatArray)[0].toInt()
-
-        for (i in 0 until numberOfFoundObjects) {
-            val detectedObject = DetectedObject(
-                classLabel = cocoCategories[classIndices[i].toInt()]!!,
-                probability = probabilities[i],
-                // top, left, bottom, right
-                yMin = boxes[i][0],
-                xMin = boxes[i][1],
-                yMax = boxes[i][2],
-                xMax = boxes[i][3]
-            )
-            foundObjects.add(detectedObject)
-        }
-
-        foundObjects.sortByDescending { it.probability }
-
-        if (topK > 0) {
-            return foundObjects.take(topK)
-        }
-
-        return foundObjects
-    }
-
-    /**
-     * Returns the top N detected object for the given image sorted by the score.
-     *
-     * NOTE: this method includes the SSD - related preprocessing.
-     *
-     * @param [image] Input image.
-     * @param [topK] The number of the detected objects with the highest score to be returned.
-     * @return List of [DetectedObject] sorted by score.
-     */
-    public fun detectObjects(image: BufferedImage, topK: Int = 5): List<DetectedObject> {
-        return detectObjects(preprocessing.apply(image).first, topK)
-    }
 
     /**
      * Returns the top N detected object for the given image file sorted by the score.

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDObjectDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDObjectDetectionModel.kt
@@ -23,9 +23,6 @@ import java.awt.image.BufferedImage
 import java.io.File
 import java.io.IOException
 
-private const val OUTPUT_BOXES = "bboxes"
-private const val OUTPUT_LABELS = "labels"
-private const val OUTPUT_SCORES = "scores"
 private const val INPUT_SIZE = 1200
 
 /**

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModel.kt
@@ -6,14 +6,9 @@
 package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
 
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
-import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
-import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
-import org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection.MultiPoseDetectionModelBase
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.MultiPoseDetectionResult
-import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
@@ -22,11 +17,10 @@ import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.convert
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.resize
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.toFloatArray
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import java.awt.image.BufferedImage
 import java.io.File
-import java.io.IOException
 
-private const val CLASS_LABEL = "person"
 private const val OUTPUT_NAME = "output_0"
 private const val INPUT_SIZE = 256
 

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModel.kt
@@ -6,11 +6,9 @@
 package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
 
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
-import org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection.SinglePoseDetectionModelBase
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
@@ -19,6 +17,7 @@ import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.convert
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.resize
 import org.jetbrains.kotlinx.dl.dataset.preprocessor.image.toFloatArray
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.IOException
@@ -54,7 +53,7 @@ public class SinglePoseDetectionModel(override val internalModel: OnnxInferenceM
      * Constructs the pose detection model from a given path.
      * @param [pathToModel] path to model
      */
-    public constructor(pathToModel: String): this(OnnxInferenceModel(pathToModel))
+    public constructor(pathToModel: String) : this(OnnxInferenceModel(pathToModel))
 
     /**
      * Detects a pose for the given [imageFile].

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/TFModelHub.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/TFModelHub.kt
@@ -12,8 +12,8 @@ import org.jetbrains.kotlinx.dl.api.core.Functional
 import org.jetbrains.kotlinx.dl.api.core.GraphTrainableModel
 import org.jetbrains.kotlinx.dl.api.core.Sequential
 import org.jetbrains.kotlinx.dl.api.core.freeze
-import org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels
 import java.io.File
 import java.net.URL
 import java.nio.file.Files

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/TFModels.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/TFModels.kt
@@ -11,12 +11,12 @@ import org.jetbrains.kotlinx.dl.api.core.Sequential
 import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
-import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.ImageRecognitionModel
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.InputType
 import org.jetbrains.kotlinx.dl.api.inference.keras.loadWeights
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
+import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
  * Supported models for inference and transfer learning, trained on ImageNet dataset.

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/TFModels.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/loaders/TFModels.kt
@@ -46,7 +46,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the VGG16 architecture.
          *
@@ -74,7 +74,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the VGG19 architecture.
          *
@@ -102,7 +102,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 18 layers with ResNetv1 architecture.
          *
@@ -123,7 +123,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 34 layers with ResNetv1 architecture.
          *
@@ -144,7 +144,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 50 layers with ResNetv1 architecture.
          *
@@ -174,7 +174,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 101 layers with ResNetv1 architecture.
          *
@@ -204,7 +204,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 152 layers with ResNetv1 architecture.
          *
@@ -234,7 +234,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 50 layers with ResNetv2 architecture.
          *
@@ -259,7 +259,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 101 layers with ResNetv2 architecture.
          *
@@ -284,7 +284,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * This model has 152 layers with ResNetv2 architecture.
          *
@@ -309,7 +309,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the MobileNet architecture.
          *
@@ -332,7 +332,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the MobileNetV2 architecture.
          *
@@ -355,7 +355,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the InceptionV3 architecture.
          *
@@ -378,7 +378,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the Xception architecture.
          *
@@ -401,7 +401,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the DenseNet121 architecture.
          *
@@ -424,7 +424,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the DenseNet169 architecture.
          *
@@ -447,7 +447,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the DenseNet201 architecture.
          *
@@ -470,7 +470,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the NASNetMobile architecture.
          *
@@ -493,7 +493,7 @@ public object TFModels {
 
         /**
          * This model is a neural network for image classification that take images as input and classify the major object in the image into a set of 1000 different classes
-         * (labels are available via [org.jetbrains.kotlinx.dl.api.core.util.loadImageNetClassLabels] method).
+         * (labels are available via [org.jetbrains.kotlinx.dl.api.inference.imagerecognition.loadImageNetClassLabels] method).
          *
          * Instantiates the NASNetLarge architecture.
          *


### PR DESCRIPTION
This PR aims at allowing to reuse the same onnx models on other platforms by extracting base classes for task specific models.

1. `OnnxPreTrainedModel` is a base for all pre-trained models which use `OnnxInferenceModel` internally (except for classification). Classification is represented separately by `ImageRecognitionModelBase`, which is reused between tensorflow and onnx modules. We can't do the same with other models since they use `OnnxInferenceModel#predictRaw` method which is unavailable in `InferenceModel` interface. It seems that `InferenceModel` is geared more towards classification and we may need to rethink it in the future.
2. There are base classes for tasks such as face alignment, object detection, pose detection, but current implementations depend on the output format and may not be very reusable.