### PR TITLE
Fix detection results coordinates

### DIFF
--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
@@ -21,7 +21,7 @@ public abstract class FaceAlignmentModelBase<I> : OnnxHighLevelModel<I, List<Lan
         val landMarks = mutableListOf<Landmark>()
         val floats = (output[outputName] as Array<*>)[0] as FloatArray
         for (i in floats.indices step 2) {
-            landMarks.add(Landmark(floats[i], floats[i + 1]))
+            landMarks.add(Landmark((1 + floats[i]) / 2, (1 + floats[i + 1]) / 2))
         }
 
         return landMarks

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
@@ -50,9 +50,9 @@ public abstract class MultiPoseDetectionModelBase<I> : OnnxHighLevelModel<I, Mul
             val detectedObject = DetectedObject(
                 classLabel = CLASS_LABEL,
                 probability = floats[55],
-                yMin = floats[53],
+                yMin = floats[51],
                 xMin = floats[52],
-                yMax = floats[51],
+                yMax = floats[53],
                 xMax = floats[54]
             )
 

--- a/visualization/src/main/kotlin/org/jetbrains/kotlinx/dl/visualization/swing/PlotConv2D.kt
+++ b/visualization/src/main/kotlin/org/jetbrains/kotlinx/dl/visualization/swing/PlotConv2D.kt
@@ -386,13 +386,13 @@ class MultiPosePointsJPanel(
 
             // y = columnIndex
             // x = rowIndex
-            val yRect = bottom
+            val yRect = top
             val xRect = left
             graphics as Graphics2D
             val stroke: Stroke = BasicStroke(6f * detectedObject.probability)
             graphics.setColor(Color.ORANGE)
             graphics.stroke = stroke
-            graphics.drawRect(xRect.toInt(), yRect.toInt(), (right - left).toInt(), (top - bottom).toInt())
+            graphics.drawRect(xRect.toInt(), yRect.toInt(), (right - left).toInt(), (bottom - top).toInt())
         }
     }
 

--- a/visualization/src/main/kotlin/org/jetbrains/kotlinx/dl/visualization/swing/PlotConv2D.kt
+++ b/visualization/src/main/kotlin/org/jetbrains/kotlinx/dl/visualization/swing/PlotConv2D.kt
@@ -537,8 +537,8 @@ class LandMarksJPanel(val image: FloatArray, val imageShape: ImageShape, private
         graphics.drawImage(bufferedImage, 0, 0, null)
 
         for (i in landmarks.indices) {
-            val xLM = (size.width / 2) * (1 + landmarks[i].xRate)
-            val yLM = (size.height / 2) * (1 + landmarks[i].yRate)
+            val xLM = size.width * landmarks[i].xRate
+            val yLM = size.height * landmarks[i].yRate
 
             graphics as Graphics2D
             val stroke1: Stroke = BasicStroke(3f)


### PR DESCRIPTION
This PR ensures that coordinates of the detection results originate from the top-left image corner:
1. Y-coordinates for the `DetectionObject` were switched in the multiple poses detection model.
2. Coordinates of the face landmarks were originating from the center, not the corner.