### PR TITLE
Remove targetRotation setter api (#454)

### DIFF
--- a/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/bitmap/Rotate.kt
+++ b/dataset/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/dataset/preprocessing/bitmap/Rotate.kt
@@ -21,6 +21,8 @@ public class Rotate(
     public var degrees: Float = 0.0f,
 ) : Operation<Bitmap, Bitmap> {
     override fun apply(input: Bitmap): Bitmap {
+        if (degrees == 0f) return input
+
         val matrix = Matrix().apply { postRotate(degrees) }
         return Bitmap.createBitmap(input, 0, 0, input.width, input.height, matrix, true)
     }

--- a/onnx/build.gradle
+++ b/onnx/build.gradle
@@ -41,6 +41,7 @@ kotlin {
         androidMain {
             dependencies {
                 api 'com.microsoft.onnxruntime:onnxruntime-mobile:1.12.1'
+                api 'androidx.camera:camera-core:1.0.0-rc03'
             }
         }
     }

--- a/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/CameraXCompatibleModel.kt
+++ b/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/CameraXCompatibleModel.kt
@@ -10,3 +10,16 @@ public interface CameraXCompatibleModel {
      */
     public var targetRotation: Int
 }
+
+/**
+ * Convenience function to execute arbitrary code with a preliminary updated target rotation.
+ * After the code is executed, the target rotation is restored to its original value.
+ *
+ * @param rotation target rotation to be set for the duration of the code execution
+ * @param function arbitrary code to be executed
+ */
+public fun <R> CameraXCompatibleModel.doWithRotation(rotation: Int, function: () -> R): R {
+    val currentRotation = targetRotation
+    targetRotation = rotation
+    return function().apply { targetRotation = currentRotation }
+}

--- a/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/CameraXCompatibleModel.kt
+++ b/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/CameraXCompatibleModel.kt
@@ -8,5 +8,5 @@ public interface CameraXCompatibleModel {
      * Target image rotation.
      * @see [ImageInfo](https://developer.android.com/reference/androidx/camera/core/ImageInfo)
      */
-    public var targetRotation: Float
+    public var targetRotation: Int
 }

--- a/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
+++ b/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/ONNXModels.kt
@@ -89,6 +89,7 @@ public object ONNXModels {
                 return ImageRecognitionModel(
                     modelHub.loadModel(this),
                     channelsFirst,
+                    preprocessor,
                     classLabels = Imagenet.V1001.labels()
                 )
             }

--- a/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/classification/ImageRecognitionModel.kt
+++ b/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/classification/ImageRecognitionModel.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dl.api.inference.onnx.classification
 
 import android.graphics.Bitmap
+import androidx.camera.core.ImageProxy
 import org.jetbrains.kotlinx.dl.api.inference.imagerecognition.ImageRecognitionModelBase
 import org.jetbrains.kotlinx.dl.api.inference.onnx.CameraXCompatibleModel
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ExecutionProviderCompatible
@@ -8,6 +9,7 @@ import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders.ExecutionProvider
 import org.jetbrains.kotlinx.dl.dataset.Imagenet
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.*
+import org.jetbrains.kotlinx.dl.dataset.preprocessing.camerax.toBitmap
 import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
@@ -19,7 +21,7 @@ public open class ImageRecognitionModel(
     private val preprocessor: Operation<Pair<FloatArray, TensorShape>, Pair<FloatArray, TensorShape>> = Identity(),
     override val classLabels: Map<Int, String> = Imagenet.V1k.labels()
 ) : ImageRecognitionModelBase<Bitmap>(internalModel), ExecutionProviderCompatible, CameraXCompatibleModel {
-    override var targetRotation: Float = 0f
+    override var targetRotation: Int = 0
 
     override val preprocessing: Operation<Bitmap, Pair<FloatArray, TensorShape>>
         get() {
@@ -33,7 +35,7 @@ public open class ImageRecognitionModel(
                     outputHeight = height.toInt()
                     outputWidth = width.toInt()
                 }
-                .rotate { degrees = targetRotation }
+                .rotate { degrees = targetRotation.toFloat() }
                 .toFloatArray { layout = if (channelsFirst) TensorLayout.NCHW else TensorLayout.NHWC }
                 .call(preprocessor)
         }
@@ -41,4 +43,38 @@ public open class ImageRecognitionModel(
     override fun initializeWith(vararg executionProviders: ExecutionProvider) {
         (internalModel as OnnxInferenceModel).initializeWith(*executionProviders)
     }
+}
+
+/**
+ * Predicts object for the given [imageProxy].
+ * Internal preprocessing is updated to rotate image to match target orientation.
+ * After prediction, internal preprocessing is restored to the original state.
+ *
+ * @param [imageProxy] Input image.
+ *
+ * @return The label of the recognized object with the highest probability.
+ */
+public fun ImageRecognitionModel.predictObject(imageProxy: ImageProxy): String {
+    val currentRotation = targetRotation
+    targetRotation = imageProxy.imageInfo.rotationDegrees
+    return predictObject(imageProxy.toBitmap()).also { targetRotation = currentRotation }
+}
+
+/**
+ * Predicts [topK] objects for the given [imageProxy].
+ * Internal preprocessing is updated to rotate image to match target orientation.
+ * After prediction, internal preprocessing is restored to the original state.
+ *
+ * @param [imageProxy] Input image.
+ * @param [topK] Number of top ranked predictions to return
+ *
+ * @return The list of pairs <label, probability> sorted from the most probable to the lowest probable.
+ */
+public fun ImageRecognitionModel.predictTopKObjects(
+    imageProxy: ImageProxy,
+    topK: Int = 5
+): List<Pair<String, Float>> {
+    val currentRotation = targetRotation
+    targetRotation = imageProxy.imageInfo.rotationDegrees
+    return predictTopKObjects(imageProxy.toBitmap(), topK).also { targetRotation = currentRotation }
 }

--- a/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDLikeModel.kt
+++ b/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDLikeModel.kt
@@ -1,12 +1,15 @@
 package org.jetbrains.kotlinx.dl.api.inference.onnx.objectdetection
 
 import android.graphics.Bitmap
+import androidx.camera.core.ImageProxy
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.CameraXCompatibleModel
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
 import org.jetbrains.kotlinx.dl.dataset.Coco
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.*
+import org.jetbrains.kotlinx.dl.dataset.preprocessing.camerax.toBitmap
 import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
 
 /**
@@ -24,7 +27,7 @@ public class SSDLikeModel(override val internalModel: OnnxInferenceModel, metada
 
     override val classLabels: Map<Int, String> = Coco.V2017.labels(zeroIndexed = true)
 
-    override var targetRotation: Float = 0f
+    override var targetRotation: Int = 0
 
     override val preprocessing: Operation<Bitmap, Pair<FloatArray, TensorShape>>
         get() = pipeline<Bitmap>()
@@ -32,10 +35,25 @@ public class SSDLikeModel(override val internalModel: OnnxInferenceModel, metada
                 outputHeight = internalModel.inputDimensions[0].toInt()
                 outputWidth = internalModel.inputDimensions[1].toInt()
             }
-            .rotate { degrees = targetRotation }
+            .rotate { degrees = targetRotation.toFloat() }
             .toFloatArray { layout = TensorLayout.NHWC }
 
     override fun close() {
         internalModel.close()
     }
+}
+
+/**
+ * Returns the detected object for the given image sorted by the score.
+ * Internal preprocessing is updated to rotate image to match target orientation.
+ * After prediction, internal preprocessing is restored to the original state.
+ *
+ * @param [imageProxy] Input image.
+ * @param [topK] The number of the detected objects with the highest score to be returned.
+ * @return List of [DetectedObject] sorted by score.
+ */
+public fun SSDLikeModel.detectObjects(imageProxy: ImageProxy, topK: Int = 3): List<DetectedObject> {
+    val currentRotation = targetRotation
+    targetRotation = imageProxy.imageInfo.rotationDegrees
+    return detectObjects(imageProxy.toBitmap(), topK).also { targetRotation = currentRotation }
 }


### PR DESCRIPTION

* Extend the ModelHub's models with an API that accepts ImageProxy as an input.

* Now user not required to set targetRotation property by hand

The rotation operation is quite expensive, so it's beneficial to make a rotation after resizing, although it makes API less intuitive.