### PR TITLE
Update ONNX version, fixes #361

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ On Windows, the following distributions are required:
 
 For inference of ONNX models on a CUDA device, you will also need to add the following dependencies to your project:
 ```groovy
-  api 'com.microsoft.onnxruntime:onnxruntime_gpu:1.11.0'
+  api 'com.microsoft.onnxruntime:onnxruntime_gpu:1.12.1'
 ```
 To find more info about ONNXRuntime and CUDA version compatibility, please refer to the [ONNXRuntime CUDA Execution Provider page](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html).
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     // to run on GPU (if CUDA is updated and machine with NVIDIA onboard)
     /*implementation 'org.tensorflow:libtensorflow:1.15.0'
     implementation 'org.tensorflow:libtensorflow_jni_gpu:1.15.0'
-    api 'com.microsoft.onnxruntime:onnxruntime_gpu:1.11.0'
+    api 'com.microsoft.onnxruntime:onnxruntime_gpu:1.12.1'
     */
 }
 

--- a/onnx/build.gradle
+++ b/onnx/build.gradle
@@ -19,7 +19,7 @@ kotlin {
         commonMain {
             dependencies {
                 api project(":api")
-                api 'com.microsoft.onnxruntime:onnxruntime:1.11.0'
+                api 'com.microsoft.onnxruntime:onnxruntime:1.12.1'
             }
         }
         jvmMain {
@@ -40,7 +40,7 @@ kotlin {
         }
         androidMain {
             dependencies {
-                api 'com.microsoft.onnxruntime:onnxruntime-mobile:1.11.0'
+                api 'com.microsoft.onnxruntime:onnxruntime-mobile:1.12.1'
             }
         }
     }


### PR DESCRIPTION
Hi, 

The current version uses the ONNX version: **1.11.0**. However, a runtime crash exists for MAC M1 devices as described [here](https://github.com/Kotlin/kotlindl/issues/361).

This PR contains a version update for ONNX API. Also, fixes the problem. 
