### PR TITLE
Move onnxruntime dependency from the common source set to the jvmMain source set

### DIFF
--- a/onnx/build.gradle
+++ b/onnx/build.gradle
@@ -19,13 +19,13 @@ kotlin {
         commonMain {
             dependencies {
                 api project(":api")
-                api 'com.microsoft.onnxruntime:onnxruntime:1.12.1'
             }
         }
         jvmMain {
             dependencies {
                 api "org.jetbrains.kotlinx:multik-core:0.2.0"
                 api "org.jetbrains.kotlinx:multik-default:0.2.0"
+                api 'com.microsoft.onnxruntime:onnxruntime:1.12.1'
             }
         }
         jvmTest {


### PR DESCRIPTION
Kotlin Multiplatform allows to use platform-dependent libraries in the common source set, so the explicit dependency is not needed. This will allow to build android package without extra onnxruntime dependency.

Fixes #455