### PR TITLE
Refactor output processing in OnnxInferenceModel prediction methods

### DIFF
--- a/examples/src/main/kotlin/examples/onnx/faces/Fan2D106.kt
+++ b/examples/src/main/kotlin/examples/onnx/faces/Fan2D106.kt
@@ -9,6 +9,7 @@ import examples.transferlearning.getFileFromResource
 import org.jetbrains.kotlinx.dl.api.inference.facealignment.Landmark
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.getFloatArray
 import org.jetbrains.kotlinx.dl.api.inference.onnx.facealignment.Fan2D106FaceAlignmentModel
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
@@ -53,11 +54,10 @@ fun main() {
             val inputImage = ImageConverter.toBufferedImage(inputFile)
             val inputData = preprocessor.apply(inputImage).first
 
-            val yhat = it.predictRaw(inputData)
-            println(yhat.values.toTypedArray().contentDeepToString())
+            val floats = it.predictRaw(inputData) { output -> output.getFloatArray("fc1") }
+            println(floats.contentToString())
 
             val landMarks = mutableListOf<Landmark>()
-            val floats = (yhat["fc1"] as Array<*>)[0] as FloatArray
             for (j in floats.indices step 2) {
                 landMarks.add(Landmark((1 + floats[j]) / 2, (1 + floats[j + 1]) / 2))
             }

--- a/examples/src/main/kotlin/examples/onnx/objectdetection/ssd/SSD.kt
+++ b/examples/src/main/kotlin/examples/onnx/objectdetection/ssd/SSD.kt
@@ -8,6 +8,7 @@ package examples.onnx.objectdetection.ssd
 import examples.transferlearning.getFileFromResource
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.getFloatArray
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.call
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
@@ -45,10 +46,10 @@ fun ssd() {
             val inputData = preprocessing.load(getFileFromResource("datasets/detection/image$i.jpg")).first
 
             val start = System.currentTimeMillis()
-            val yhat = it.predictRaw(inputData)
+            val yhat = it.predictRaw(inputData) { output -> output.getFloatArray(0)}
             val end = System.currentTimeMillis()
             println("Prediction took ${end - start} ms")
-            println(yhat.values.toTypedArray().contentDeepToString())
+            println(yhat.contentToString())
         }
     }
 }

--- a/examples/src/main/kotlin/examples/onnx/posedetection/multipose/multiPoseDetectionMoveNet.kt
+++ b/examples/src/main/kotlin/examples/onnx/posedetection/multipose/multiPoseDetectionMoveNet.kt
@@ -9,6 +9,7 @@ import examples.transferlearning.getFileFromResource
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.get2DFloatArray
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.MultiPoseDetectionResult
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
@@ -51,10 +52,11 @@ fun multiPoseDetectionMoveNet() {
             .call(modelType.preprocessor)
 
         val inputData = preprocessor.apply(inputImage).first
-        val yhat = it.predictRaw(inputData)
-        println(yhat.values.toTypedArray().contentDeepToString())
+        val rawPoseLandmarks = it.predictRaw(inputData) { result ->
+            result.get2DFloatArray("output_0")
+        }
+        println(rawPoseLandmarks.contentDeepToString())
 
-        val rawPoseLandmarks = (yhat["output_0"] as Array<Array<FloatArray>>)[0]
         val poses = rawPoseLandmarks.mapNotNull { floats ->
             val probability = floats[55]
             if (probability < 0.05) return@mapNotNull null

--- a/examples/src/main/kotlin/examples/onnx/posedetection/singlepose/poseDetectionMoveNet.kt
+++ b/examples/src/main/kotlin/examples/onnx/posedetection/singlepose/poseDetectionMoveNet.kt
@@ -8,6 +8,7 @@ package examples.onnx.posedetection.singlepose
 import examples.transferlearning.getFileFromResource
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.get2DFloatArray
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
@@ -49,10 +50,10 @@ fun poseDetectionMoveNet() {
 
         val inputData = preprocessing.apply(image).first
 
-        val yhat = it.predictRaw(inputData)
-        println(yhat.values.toTypedArray().contentDeepToString())
-
-        val rawPoseLandMarks = (yhat["output_0"] as Array<Array<Array<FloatArray>>>)[0][0]
+        val rawPoseLandMarks = it.predictRaw(inputData) { result ->
+            result.get2DFloatArray("output_0")
+        }
+        println(rawPoseLandMarks.contentDeepToString())
 
         // Dictionary that maps from joint names to keypoint indices.
         val keypoints = mapOf(

--- a/examples/src/test/kotlin/examples/onnx/faces/FacesTestSuite.kt
+++ b/examples/src/test/kotlin/examples/onnx/faces/FacesTestSuite.kt
@@ -8,6 +8,7 @@ package examples.onnx.faces
 import examples.transferlearning.getFileFromResource
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.getFloatArray
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.call
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
@@ -56,8 +57,8 @@ class FacesTestSuite {
                 val imageFile = getFileFromResource("datasets/faces/image$i.jpg")
                 val inputData = fileDataLoader.load(imageFile).first
 
-                val yhat = it.predictRaw(inputData)
-                assertEquals(212, (yhat.values.toTypedArray()[0] as Array<FloatArray>)[0].size)
+                val yhat = it.predictRaw(inputData) { output -> output.getFloatArray(0) }
+                assertEquals(212, yhat.size)
             }
         }
     }

--- a/examples/src/test/kotlin/examples/onnx/posedetection/PoseDetectionTestSuite.kt
+++ b/examples/src/test/kotlin/examples/onnx/posedetection/PoseDetectionTestSuite.kt
@@ -8,6 +8,7 @@ package examples.onnx.posedetection
 import examples.transferlearning.getFileFromResource
 import org.jetbrains.kotlinx.dl.api.inference.loaders.ONNXModelHub
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.get2DFloatArray
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.call
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.pipeline
@@ -84,9 +85,9 @@ class PoseDetectionTestSuite {
 
             val inputData = fileDataLoader.load(imageFile).first
 
-            val yhat = it.predictRaw(inputData)
-
-            val rawPoseLandMarks = (yhat["output_0"] as Array<Array<Array<FloatArray>>>)[0][0]
+            val rawPoseLandMarks = it.predictRaw(inputData) { result ->
+                result.get2DFloatArray("output_0")
+            }
 
             assertEquals(17, rawPoseLandMarks.size)
         }
@@ -113,9 +114,9 @@ class PoseDetectionTestSuite {
 
             val inputData = preprocessing.load(imageFile).first
 
-            val yhat = it.predictRaw(inputData)
-
-            val rawPoseLandMarks = (yhat["output_0"] as Array<Array<Array<FloatArray>>>)[0][0]
+            val rawPoseLandMarks = it.predictRaw(inputData) { result ->
+                result.get2DFloatArray("output_0")
+            }
 
             assertEquals(17, rawPoseLandMarks.size)
         }
@@ -142,10 +143,10 @@ class PoseDetectionTestSuite {
 
 
             val inputData = dataLoader.load(imageFile).first
-            val yhat = inferenceModel.predictRaw(inputData)
-            println(yhat.values.toTypedArray().contentDeepToString())
-
-            val rawPosesLandMarks = (yhat["output_0"] as Array<Array<FloatArray>>)[0]
+            val rawPosesLandMarks = inferenceModel.predictRaw(inputData) { result ->
+                result.get2DFloatArray("output_0")
+            }
+            println(rawPosesLandMarks.contentDeepToString())
 
             assertEquals(6, rawPosesLandMarks.size)
             rawPosesLandMarks.forEach {

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxHighLevelModel.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OnnxHighLevelModel.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx
 
+import ai.onnxruntime.OrtSession
 import org.jetbrains.kotlinx.dl.api.inference.onnx.executionproviders.ExecutionProvider
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.dataset.shape.TensorShape
@@ -29,15 +30,14 @@ public interface OnnxHighLevelModel<I, R> : ExecutionProviderCompatible {
     /**
      * Converts raw model output to the result.
      */
-    public fun convert(output: Map<String, Any>): R
+    public fun convert(output: OrtSession.Result): R
 
     /**
      * Makes prediction on the given [input].
      */
     public fun predict(input: I): R {
         val preprocessedInput = preprocessing.apply(input)
-        val output = internalModel.predictRaw(preprocessedInput.first)
-        return convert(output)
+        return internalModel.predictRaw(preprocessedInput.first) { convert(it) }
     }
 
     override fun initializeWith(vararg executionProviders: ExecutionProvider) {

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OrtSessionResultConversions.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OrtSessionResultConversions.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.onnx
+
+import ai.onnxruntime.*
+
+/**
+ * Convenience functions for processing [OrtSession.Result].
+ */
+public object OrtSessionResultConversions {
+    /**
+     * Returns the output at [index] as a [FloatArray] with its shape.
+     */
+    public fun OrtSession.Result.getFloatArrayWithShape(index: Int): Pair<FloatArray, LongArray> {
+        return get(index).getFloatArrayWithShape()
+    }
+
+    /**
+     * Returns the output at [index] as a [FloatArray].
+     */
+    public fun OrtSession.Result.getFloatArray(index: Int): FloatArray {
+        return getFloatArrayWithShape(index).first
+    }
+
+    /**
+     * Returns the output by [name] as a [FloatArray] with its shape.
+     */
+    public fun OrtSession.Result.getFloatArrayWithShape(name: String): Pair<FloatArray, LongArray> {
+        return get(name).get().getFloatArrayWithShape()
+    }
+
+    /**
+     * Returns the output by [name] as a [FloatArray].
+     */
+    public fun OrtSession.Result.getFloatArray(name: String): FloatArray {
+        return getFloatArrayWithShape(name).first
+    }
+
+    private fun OnnxValue.getFloatArrayWithShape(): Pair<FloatArray, LongArray> {
+        throwIfOutputNotSupported(info, toString(), "getFloatArray", OnnxJavaType.FLOAT)
+        val shape = (info as TensorInfo).shape
+        return (this as OnnxTensor).floatBuffer.array() to shape
+    }
+
+    /**
+     * Returns the output at [index] as a [DoubleArray] with its shape.
+     */
+    public fun OrtSession.Result.getDoubleArrayWithShape(index: Int): Pair<DoubleArray, LongArray> {
+        return get(index).getDoubleArrayWithShape()
+    }
+
+    /**
+     * Returns the output at [index] as a [DoubleArray].
+     */
+    public fun OrtSession.Result.getDoubleArray(index: Int): DoubleArray {
+        return getDoubleArrayWithShape(index).first
+    }
+
+    /**
+     * Returns the output by [name] as a [DoubleArray] with its shape.
+     */
+    public fun OrtSession.Result.getDoubleArrayWithShape(name: String): Pair<DoubleArray, LongArray> {
+        return get(name).get().getDoubleArrayWithShape()
+    }
+
+    /**
+     * Returns the output by [name] as a [DoubleArray].
+     */
+    public fun OrtSession.Result.getDoubleArray(name: String): DoubleArray {
+        return getDoubleArrayWithShape(name).first
+    }
+
+    private fun OnnxValue.getDoubleArrayWithShape(): Pair<DoubleArray, LongArray> {
+        throwIfOutputNotSupported(info, toString(), "getDoubleArray", OnnxJavaType.DOUBLE)
+        val shape = (info as TensorInfo).shape
+        return (this as OnnxTensor).doubleBuffer.array() to shape
+    }
+
+    /**
+     * Returns the output at [index] as a [LongArray] with its shape.
+     */
+    public fun OrtSession.Result.getLongArrayWithShape(index: Int): Pair<LongArray, LongArray> {
+        return get(index).getLongArrayWithShape()
+    }
+
+    /**
+     * Returns the output at [index] as a [LongArray].
+     */
+    public fun OrtSession.Result.getLongArray(index: Int): LongArray {
+        return getLongArrayWithShape(index).first
+    }
+
+    /**
+     * Returns the output by [name] as a [LongArray] with its shape.
+     */
+    public fun OrtSession.Result.getLongArrayWithShape(name: String): Pair<LongArray, LongArray> {
+        return get(name).get().getLongArrayWithShape()
+    }
+
+    /**
+     * Returns the output by [name] as a [FloatArray].
+     */
+    public fun OrtSession.Result.getLongArray(name: String): LongArray {
+        return getLongArrayWithShape(name).first
+    }
+
+    private fun OnnxValue.getLongArrayWithShape(): Pair<LongArray, LongArray> {
+        throwIfOutputNotSupported(info, toString(), "getLongArray", OnnxJavaType.INT64)
+        val shape = (info as TensorInfo).shape
+        return (this as OnnxTensor).longBuffer.array() to shape
+    }
+
+    /**
+     * Returns the output at [index] as an [IntArray] with its shape.
+     */
+    public fun OrtSession.Result.getIntArrayWithShape(index: Int): Pair<IntArray, LongArray> {
+        return get(index).getIntArrayWithShape()
+    }
+
+    /**
+     * Returns the output at [index] as an [IntArray].
+     */
+    public fun OrtSession.Result.getIntArray(index: Int): IntArray {
+        return getIntArrayWithShape(index).first
+    }
+
+    /**
+     * Returns the output by [name] as an [IntArray] with its shape.
+     */
+    public fun OrtSession.Result.getIntArrayWithShape(name: String): Pair<IntArray, LongArray> {
+        return get(name).get().getIntArrayWithShape()
+    }
+
+    /**
+     * Returns the output by [name] as an [IntArray].
+     */
+    public fun OrtSession.Result.getIntArray(name: String): IntArray {
+        return getIntArrayWithShape(name).first
+    }
+
+    private fun OnnxValue.getIntArrayWithShape(): Pair<IntArray, LongArray> {
+        throwIfOutputNotSupported(info, toString(), "getIntArray", OnnxJavaType.INT32)
+        val shape = (info as TensorInfo).shape
+        return (this as OnnxTensor).intBuffer.array() to shape
+    }
+
+    /**
+     * Returns the output at [index] as a [ShortArray] with its shape.
+     */
+    public fun OrtSession.Result.getShortArrayWithShape(index: Int): Pair<ShortArray, LongArray> {
+        return get(index).getShortArrayWithShape()
+    }
+
+    /**
+     * Returns the output at [index] as a [ShortArray].
+     */
+    public fun OrtSession.Result.getShortArray(index: Int): ShortArray {
+        return getShortArrayWithShape(index).first
+    }
+
+    /**
+     * Returns the output by [name] as a [ShortArray] with its shape.
+     */
+    public fun OrtSession.Result.getShortArrayWithShape(name: String): Pair<ShortArray, LongArray> {
+        return get(name).get().getShortArrayWithShape()
+    }
+
+    /**
+     * Returns the output by [name] as a [ShortArray].
+     */
+    public fun OrtSession.Result.getShortArray(name: String): ShortArray {
+        return getShortArrayWithShape(name).first
+    }
+
+    private fun OnnxValue.getShortArrayWithShape(): Pair<ShortArray, LongArray> {
+        throwIfOutputNotSupported(info, toString(), "getShortArray", OnnxJavaType.INT16)
+        val shape = (info as TensorInfo).shape
+        return (this as OnnxTensor).shortBuffer.array() to shape
+    }
+
+    /**
+     * Returns the output at [index] as a [ByteArray] with its shape.
+     */
+    public fun OrtSession.Result.getByteArrayWithShape(index: Int): Pair<ByteArray, LongArray> {
+        return get(index).getByteArrayWithShape()
+    }
+
+    /**
+     * Returns the output at [index] as a [ByteArray].
+     */
+    public fun OrtSession.Result.getByteArray(index: Int): ByteArray {
+        return getByteArrayWithShape(index).first
+    }
+
+    /**
+     * Returns the output by [name] as a [ByteArray] with its shape.
+     */
+    public fun OrtSession.Result.getByteArrayWithShape(name: String): Pair<ByteArray, LongArray> {
+        return get(name).get().getByteArrayWithShape()
+    }
+
+    /**
+     * Returns the output by [name] as a [ByteArray].
+     */
+    public fun OrtSession.Result.getByteArray(name: String): ByteArray {
+        return getByteArrayWithShape(name).first
+    }
+
+    private fun OnnxValue.getByteArrayWithShape(): Pair<ByteArray, LongArray> {
+        throwIfOutputNotSupported(info, toString(), "getByteArray", OnnxJavaType.STRING)
+        val shape = (info as TensorInfo).shape
+        return (this as OnnxTensor).byteBuffer.array() to shape
+    }
+
+    /**
+     * Returns all values from this [OrtSession.Result]. This operation could be slow for high dimensional tensors,
+     * in which case functions that return one dimensional array such as [getFloatArray] or [getLongArray] should be used.
+     * @see OnnxValue.getValue
+     */
+    public fun OrtSession.Result.getValues(): Map<String, Any> = associate { it.key to it.value.value }
+
+    /**
+     * Checks if [valueInfo] corresponds to a Tensor of the specified [type].
+     * If it does not satisfy the requirements, exception with a message containing [valueName] and calling [method] name is thrown.
+     */
+    internal fun throwIfOutputNotSupported(valueInfo: ValueInfo,
+                                           valueName: String,
+                                           method: String,
+                                           type: OnnxJavaType
+    ) {
+        require(valueInfo !is MapInfo) { "Output $valueName is a Map, but currently method $method supports only $type Tensor outputs." }
+        require(valueInfo !is SequenceInfo) { "Output '$valueName' is a Sequence, but currently method $method supports $type float Tensor outputs." }
+        require(valueInfo is TensorInfo && valueInfo.type == type) { "Currently method $method supports only $type Tensor outputs, but output '$valueName' is not a float Tensor." }
+    }
+}

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OrtSessionResultConversions.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/OrtSessionResultConversions.kt
@@ -216,6 +216,37 @@ public object OrtSessionResultConversions {
     }
 
     /**
+     * Returns the output by [name] as an Array<FloatArray>. This operation could be slow for high dimensional tensors,
+     * in which case [getFloatArray] should be used.
+     */
+    public fun OrtSession.Result.get2DFloatArray(name: String): Array<FloatArray> {
+        return get(name).get().get2DFloatArray()
+    }
+
+    /**
+     * Returns the output at [index] as an Array<FloatArray>. This operation could be slow for high dimensional tensors,
+     * in which case [getFloatArray] should be used.
+     */
+    public fun OrtSession.Result.get2DFloatArray(index: Int): Array<FloatArray> {
+        return get(index).get2DFloatArray()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun OnnxValue.get2DFloatArray(): Array<FloatArray> {
+        throwIfOutputNotSupported(info, toString(), "get2DFloatArray", OnnxJavaType.FLOAT)
+        val shape = (info as TensorInfo).shape
+        val depth = shape.size - 2
+        require(depth >= 0 && shape.slice(0 until depth).all { it == 1L }) {
+            "Output of shape $shape can't be converted to the Array<FloatArray>."
+        }
+        var result = value as Array<*>
+        repeat(depth) {
+            result = result[0] as Array<*>
+        }
+        return result as Array<FloatArray>
+    }
+
+    /**
      * Returns all values from this [OrtSession.Result]. This operation could be slow for high dimensional tensors,
      * in which case functions that return one dimensional array such as [getFloatArray] or [getLongArray] should be used.
      * @see OnnxValue.getValue

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceAlignmentModelBase.kt
@@ -5,8 +5,10 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.facealignment
 
+import ai.onnxruntime.OrtSession
 import org.jetbrains.kotlinx.dl.api.inference.facealignment.Landmark
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.getFloatArray
 
 /**
  * Base class for face alignment models.
@@ -17,9 +19,9 @@ public abstract class FaceAlignmentModelBase<I> : OnnxHighLevelModel<I, List<Lan
      */
     protected abstract val outputName: String
 
-    override fun convert(output: Map<String, Any>): List<Landmark> {
+    override fun convert(output: OrtSession.Result): List<Landmark> {
         val landMarks = mutableListOf<Landmark>()
-        val floats = (output[outputName] as Array<*>)[0] as FloatArray
+        val floats = output.getFloatArray(outputName)
         for (i in floats.indices step 2) {
             landMarks.add(Landmark((1 + floats[i]) / 2, (1 + floats[i + 1]) / 2))
         }

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/facealignment/FaceDetectionModelBase.kt
@@ -5,8 +5,10 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.facealignment
 
+import ai.onnxruntime.OrtSession
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.get2DFloatArray
 import java.lang.Float.min
 import kotlin.math.max
 
@@ -15,9 +17,9 @@ import kotlin.math.max
  */
 public abstract class FaceDetectionModelBase<I> : OnnxHighLevelModel<I, List<DetectedObject>> {
 
-    override fun convert(output: Map<String, Any>): List<DetectedObject> {
-        val scores = (output["scores"] as Array<*>)[0] as Array<FloatArray>
-        val boxes = (output["boxes"] as Array<*>)[0] as Array<FloatArray>
+    override fun convert(output: OrtSession.Result): List<DetectedObject> {
+        val scores = output.get2DFloatArray("scores")
+        val boxes = output.get2DFloatArray("boxes")
 
         if (scores.isEmpty()) return emptyList()
 

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/ObjectDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/ObjectDetectionModelBase.kt
@@ -5,8 +5,11 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.objectdetection
 
+import ai.onnxruntime.OrtSession
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.get2DFloatArray
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.getFloatArray
 
 /**
  * Base class for object detection models.
@@ -38,9 +41,9 @@ public abstract class ObjectDetectionModelBase<I> : OnnxHighLevelModel<I, List<D
  */
 public abstract class EfficientDetObjectDetectionModelBase<I> : ObjectDetectionModelBase<I>() {
 
-    override fun convert(output: Map<String, Any>): List<DetectedObject> {
+    override fun convert(output: OrtSession.Result): List<DetectedObject> {
         val foundObjects = mutableListOf<DetectedObject>()
-        val items = (output[OUTPUT_NAME] as Array<Array<FloatArray>>)[0]
+        val items = output.get2DFloatArray(OUTPUT_NAME)
 
         for (i in items.indices) {
             val probability = items[i][5]
@@ -69,10 +72,10 @@ public abstract class EfficientDetObjectDetectionModelBase<I> : ObjectDetectionM
  * Base class for object detection model based on SSD architecture.
  */
 public abstract class SSDLikeModelBase<I>(protected val metadata: SSDLikeModelMetadata) : ObjectDetectionModelBase<I>() {
-    override fun convert(output: Map<String, Any>): List<DetectedObject> {
-        val boxes = (output[metadata.outputBoxesName] as Array<Array<FloatArray>>)[0]
-        val classIndices = (output[metadata.outputClassesName] as Array<FloatArray>)[0]
-        val probabilities = (output[metadata.outputScoresName] as Array<FloatArray>)[0]
+    override fun convert(output: OrtSession.Result): List<DetectedObject> {
+        val boxes = output.get2DFloatArray(metadata.outputBoxesName)
+        val classIndices = output.getFloatArray(metadata.outputClassesName)
+        val probabilities = output.getFloatArray(metadata.outputScoresName)
         val numberOfFoundObjects = boxes.size
 
         val foundObjects = mutableListOf<DetectedObject>()

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/MultiPoseDetectionModelBase.kt
@@ -5,8 +5,10 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
 
+import ai.onnxruntime.OrtSession
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.get2DFloatArray
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.MultiPoseDetectionResult
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
@@ -30,8 +32,8 @@ public abstract class MultiPoseDetectionModelBase<I> : OnnxHighLevelModel<I, Mul
      */
     protected abstract val edgeKeyPoints: List<Pair<Int, Int>>
 
-    override fun convert(output: Map<String, Any>): MultiPoseDetectionResult {
-        val rawPoseLandMarks = (output[outputName] as Array<Array<FloatArray>>)[0]
+    override fun convert(output: OrtSession.Result): MultiPoseDetectionResult {
+        val rawPoseLandMarks = output.get2DFloatArray(outputName)
 
         val poses = rawPoseLandMarks.map { floats ->
             val foundPoseLandmarks = mutableListOf<PoseLandmark>()

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModelBase.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/posedetection/SinglePoseDetectionModelBase.kt
@@ -5,7 +5,9 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.posedetection
 
+import ai.onnxruntime.OrtSession
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxHighLevelModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.get2DFloatArray
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.DetectedPose
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseEdge
 import org.jetbrains.kotlinx.dl.api.inference.posedetection.PoseLandmark
@@ -33,8 +35,8 @@ public abstract class SinglePoseDetectionModelBase<I> : OnnxHighLevelModel<I, De
      */
     protected val edgeKeyPoints: List<Pair<Int, Int>> = edgeKeyPointsPairs
 
-    override fun convert(output: Map<String, Any>): DetectedPose {
-        val rawPoseLandMarks = (output[outputName] as Array<Array<Array<FloatArray>>>)[0][0]
+    override fun convert(output: OrtSession.Result): DetectedPose {
+        val rawPoseLandMarks = output.get2DFloatArray(outputName)
 
         val foundPoseLandmarks = mutableListOf<PoseLandmark>()
         for (i in rawPoseLandMarks.indices) {

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDObjectDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/api/inference/onnx/objectdetection/SSDObjectDetectionModel.kt
@@ -5,10 +5,14 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.onnx.objectdetection
 
+import ai.onnxruntime.OrtSession
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 import org.jetbrains.kotlinx.dl.api.inference.onnx.ONNXModels
 import org.jetbrains.kotlinx.dl.api.inference.onnx.OnnxInferenceModel
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.get2DFloatArray
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.getFloatArray
+import org.jetbrains.kotlinx.dl.api.inference.onnx.OrtSessionResultConversions.getLongArray
 import org.jetbrains.kotlinx.dl.dataset.Coco
 import org.jetbrains.kotlinx.dl.dataset.image.ColorMode
 import org.jetbrains.kotlinx.dl.dataset.image.ImageConverter
@@ -80,10 +84,10 @@ public class SSDObjectDetectionModel(override val internalModel: OnnxInferenceMo
     }
 
     // TODO remove code duplication due to different type of class labels array
-    override fun convert(output: Map<String, Any>): List<DetectedObject> {
-        val boxes = (output[metadata.outputBoxesName] as Array<Array<FloatArray>>)[0]
-        val classIndices = (output[metadata.outputClassesName] as Array<LongArray>)[0]
-        val probabilities = (output[metadata.outputScoresName] as Array<FloatArray>)[0]
+    override fun convert(output: OrtSession.Result): List<DetectedObject> {
+        val boxes = output.get2DFloatArray(metadata.outputBoxesName)
+        val classIndices = output.getLongArray(metadata.outputClassesName)
+        val probabilities = output.getFloatArray(metadata.outputScoresName)
         val numberOfFoundObjects = boxes.size
 
         val foundObjects = mutableListOf<DetectedObject>()


### PR DESCRIPTION
This PR adds:
1. Function `OnnxInferenceModel.predictRaw` is introduced to be used for custom output processing and in other prediction methods to remove duplication between them.
2. Utility functions to extract prediction result without casts from the `OrtSession.Result` object. There are separate functions for each buffer type, unfortunately did not find a way to implement them without copy-paste.

This allows to get rid of `predictRawWithShapes` method and replace it with the more customizable alternative. Also we can now pass `OrtSession.Result` directly to the `OnnxHighLevelModel#convert` function.

Fixes #358