### PR TITLE
Change onnxruntime dependency for Android platform

### DIFF
--- a/onnx/build.gradle
+++ b/onnx/build.gradle
@@ -42,7 +42,7 @@ kotlin {
         }
         androidMain {
             dependencies {
-                api 'com.microsoft.onnxruntime:onnxruntime-mobile:1.12.1'
+                api 'com.microsoft.onnxruntime:onnxruntime-android:1.12.1'
                 api 'androidx.camera:camera-core:1.0.0-rc03'
             }
         }


### PR DESCRIPTION
Replace onnxruntime-mobile with onnxruntime-android in order to support both .ort and .onnx models on android