### PR TITLE
Add a Crop operation for Android Bitmap

### DIFF
--- a/impl/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/impl/preprocessing/Preprocessing.kt
+++ b/impl/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/impl/preprocessing/Preprocessing.kt
@@ -6,9 +6,12 @@
 package org.jetbrains.kotlinx.dl.impl.preprocessing
 
 import android.graphics.Bitmap
+import android.os.Build
+import androidx.annotation.RequiresApi
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.api.preprocessing.PreprocessingPipeline
+import org.jetbrains.kotlinx.dl.impl.preprocessing.bitmap.Crop
 import org.jetbrains.kotlinx.dl.impl.preprocessing.bitmap.Resize
 import org.jetbrains.kotlinx.dl.impl.preprocessing.bitmap.Rotate
 
@@ -29,4 +32,10 @@ public fun <I> Operation<I, Bitmap>.resize(block: Resize.() -> Unit): Operation<
 /** Applies [Rotate] operation to rotate the [Bitmap] by an arbitrary angle (specified in degrees). */
 public fun <I> Operation<I, Bitmap>.rotate(block: Rotate.() -> Unit): Operation<I, Bitmap> {
     return PreprocessingPipeline(this, Rotate().apply(block))
+}
+
+/** Applies [Crop] operation to crop the [Bitmap] at a specified region. */
+@RequiresApi(Build.VERSION_CODES.O)
+public fun <I> Operation<I, Bitmap>.crop(block: Crop.() -> Unit): Operation<I, Bitmap> {
+    return PreprocessingPipeline(this, Crop().apply(block))
 }

--- a/impl/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/impl/preprocessing/bitmap/Crop.kt
+++ b/impl/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/impl/preprocessing/bitmap/Crop.kt
@@ -64,10 +64,6 @@ public class Crop(
     }
 
     override fun getOutputShape(inputShape: TensorShape): TensorShape {
-        return when (inputShape.rank()) {
-            2 -> TensorShape(width.toLong(), height.toLong())
-            3 -> TensorShape(width.toLong(), height.toLong(), inputShape[2])
-            else -> throw IllegalArgumentException("Input shape must expected to be 2D or 3D")
-        }
+        return Resize.createOutputImageShape(inputShape, width, height)
     }
 }

--- a/impl/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/impl/preprocessing/bitmap/Crop.kt
+++ b/impl/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/impl/preprocessing/bitmap/Crop.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.impl.preprocessing.bitmap
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorSpace
+import android.graphics.Rect
+import android.os.Build
+import androidx.annotation.RequiresApi
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.preprocessing.Operation
+
+/**
+ * This class defines the Crop [Operation].
+ *
+ * Crop operation crops the given image at the specified location and size.
+ * If the cropped region does not fit into the input image, the image is padded first and then cropped.
+ *
+ * @property [x]      cropped region top-left corner x-coordinate
+ * @property [y]      cropped region top-left corner y-coordinate
+ * @property [width]  cropped region width
+ * @property [height] cropped region height
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+public class Crop(
+    public var x: Int = 0,
+    public var y: Int = 0,
+    public var width: Int = 0,
+    public var height: Int = 0,
+) : Operation<Bitmap, Bitmap> {
+
+    override fun apply(input: Bitmap): Bitmap {
+        if (width < 0 || height < 0) {
+            throw IllegalArgumentException(
+                "Negative crop width and height are not allowed. " +
+                        "Current parameters: width = $width, height = $height"
+            )
+        }
+        if (x == 0 && y == 0 && width == input.width && height == input.height) {
+            return input
+        }
+        if (x >= 0 && y >= 0 && x + width <= input.width && y + height <= input.height) {
+            return Bitmap.createBitmap(input, x, y, width, height)
+        }
+        val output = Bitmap.createBitmap(
+            width, height, input.config, input.hasAlpha(),
+            input.colorSpace ?: ColorSpace.get(ColorSpace.Named.SRGB)
+        )
+        val inputRect = Rect(
+            x.coerceAtLeast(0),
+            y.coerceAtLeast(0),
+            (x + width).coerceAtMost(input.width),
+            (y + height).coerceAtMost(input.height)
+        )
+        val outputRect = Rect(inputRect).apply {
+            offsetTo((-x).coerceAtLeast(0), (-y).coerceAtLeast(0))
+        }
+        Canvas(output).drawBitmap(input, inputRect, outputRect, null)
+        return output
+    }
+
+    override fun getOutputShape(inputShape: TensorShape): TensorShape {
+        return when (inputShape.rank()) {
+            2 -> TensorShape(width.toLong(), height.toLong())
+            3 -> TensorShape(width.toLong(), height.toLong(), inputShape[2])
+            else -> throw IllegalArgumentException("Input shape must expected to be 2D or 3D")
+        }
+    }
+}

--- a/impl/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/impl/preprocessing/bitmap/Resize.kt
+++ b/impl/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/impl/preprocessing/bitmap/Resize.kt
@@ -29,10 +29,16 @@ public class Resize(
     }
 
     override fun getOutputShape(inputShape: TensorShape): TensorShape {
-        return when (inputShape.rank()) {
-            2 -> TensorShape(outputWidth.toLong(), outputHeight.toLong())
-            3 -> TensorShape(outputWidth.toLong(), outputHeight.toLong(), inputShape[2])
-            else -> throw IllegalArgumentException("Input shape must expected to be 2D or 3D")
+        return createOutputImageShape(inputShape, outputWidth, outputHeight)
+    }
+
+    public companion object {
+        internal fun createOutputImageShape(inputShape: TensorShape, outputWidth: Int, outputHeight: Int): TensorShape {
+            return when (inputShape.rank()) {
+                2 -> TensorShape(outputWidth.toLong(), outputHeight.toLong())
+                3 -> TensorShape(outputWidth.toLong(), outputHeight.toLong(), inputShape[2])
+                else -> throw IllegalArgumentException("Input shape is expected to be 2D or 3D")
+            }
         }
     }
 }


### PR DESCRIPTION
This operation is useful for combining face detection and face alignment models (since face alignment model needs to have an approximate face location on the image).