### PR TITLE
Add a FlatShape interface to allow manipulating the detected shapes in a unified way

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/FlatShape.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/FlatShape.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference
+
+/**
+ * Represents a 2D geometric shape.
+ */
+public interface FlatShape<T : FlatShape<T>> {
+    /**
+     * Creates a new geometric shape of the same type by applying the provided [mapping] to the coordinates of the current shape.
+     */
+    public fun map(mapping: (Float, Float) -> Pair<Float, Float>): T
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/facealignment/Landmark.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/facealignment/Landmark.kt
@@ -5,8 +5,15 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.facealignment
 
+import org.jetbrains.kotlinx.dl.api.inference.FlatShape
+
 /**
  * Represents a face landmark as a point on the image with two coordinates relative to the top-left corner.
  * Both coordinates have values between 0 and 1.
  * */
-public data class Landmark(public val x: Float, public val y: Float)
+public data class Landmark(public val x: Float, public val y: Float): FlatShape<Landmark> {
+    override fun map(mapping: (Float, Float) -> Pair<Float, Float>): Landmark {
+        val (x1, y1) = mapping(x, y)
+        return Landmark(x1, y1)
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/objectdetection/DetectedObject.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/objectdetection/DetectedObject.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.objectdetection
 
+import org.jetbrains.kotlinx.dl.api.inference.FlatShape
+
 /**
  * This data class represents the detected object on the given image.
  *
@@ -22,4 +24,10 @@ public data class DetectedObject(
     val yMax: Float,
     val probability: Float,
     val label: String? = null
-)
+): FlatShape<DetectedObject> {
+    override fun map(mapping: (Float, Float) -> Pair<Float, Float>): DetectedObject {
+        val (xMin1, yMin1) = mapping(xMin, yMin)
+        val (xMax1, yMax1) = mapping(xMax, yMax)
+        return DetectedObject(xMin1, xMax1, yMin1, yMax1, probability, label)
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/posedetection/DetectedPose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/posedetection/DetectedPose.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.posedetection
 
+import org.jetbrains.kotlinx.dl.api.inference.FlatShape
+
 /**
  * This data class represents the human's pose detected on the given image.
  *
@@ -14,4 +16,8 @@ package org.jetbrains.kotlinx.dl.api.inference.posedetection
 public data class DetectedPose(
     val landmarks: List<PoseLandmark>,
     val edges: List<PoseEdge>
-)
+) : FlatShape<DetectedPose> {
+    override fun map(mapping: (Float, Float) -> Pair<Float, Float>): DetectedPose {
+        return DetectedPose(landmarks.map { it.map(mapping) }, edges.map { it.map(mapping) })
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/posedetection/MultiPoseDetectionResult.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/posedetection/MultiPoseDetectionResult.kt
@@ -5,10 +5,15 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.posedetection
 
+import org.jetbrains.kotlinx.dl.api.inference.FlatShape
 import org.jetbrains.kotlinx.dl.api.inference.objectdetection.DetectedObject
 
 /** This data class represents a few detected poses on the given image. */
 public data class MultiPoseDetectionResult(
     /** The list of pairs DetectedObject - DetectedPose. */
     val poses: List<Pair<DetectedObject, DetectedPose>>
-)
+) : FlatShape<MultiPoseDetectionResult> {
+    override fun map(mapping: (Float, Float) -> Pair<Float, Float>): MultiPoseDetectionResult {
+        return MultiPoseDetectionResult(poses.map { it.first.map(mapping) to it.second.map(mapping) })
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/posedetection/PoseEdge.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/posedetection/PoseEdge.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.kotlinx.dl.api.inference.posedetection
 
+import org.jetbrains.kotlinx.dl.api.inference.FlatShape
+
 /**
  * This data class represents the line connecting two points [PoseLandmark] of human's pose.
  *
@@ -13,4 +15,8 @@ public data class PoseEdge(
     val end: PoseLandmark,
     val probability: Float,
     val label: String,
-)
+) : FlatShape<PoseEdge> {
+    override fun map(mapping: (Float, Float) -> Pair<Float, Float>): PoseEdge {
+        return PoseEdge(start.map(mapping), end.map(mapping), probability, label)
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/posedetection/PoseLandmark.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/posedetection/PoseLandmark.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.posedetection
 
+import org.jetbrains.kotlinx.dl.api.inference.FlatShape
+
 /**
  * This data class represents one point of the detected human's pose.
  *
@@ -18,4 +20,9 @@ public data class PoseLandmark(
     val y: Float,
     val probability: Float,
     val label: String,
-)
+): FlatShape<PoseLandmark> {
+    override fun map(mapping: (Float, Float) -> Pair<Float, Float>): PoseLandmark {
+        val (x1, y1) = mapping(x, y)
+        return PoseLandmark(x1, y1, probability, label)
+    }
+}


### PR DESCRIPTION
Adding a common interface allows to simplify writing code like this:

```
private fun <T : FlatShape<T>> T.flip(): T {
    return map { x, y -> 1 - x to y }
}

private fun <T : FlatShape<T>> T.flipIfNeeded(isImageFlipped: Boolean): T {
    if (isImageFlipped) return flip()
    return this
}
```

Flipping detection results horizontally is used on Android when the front camera is used.