### PR TITLE
Keep dataset shape and use shaped data for training and prediction

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/InferenceModel.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/InferenceModel.kt
@@ -1,9 +1,11 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
 package org.jetbrains.kotlinx.dl.api.inference
+
+import org.jetbrains.kotlinx.dl.api.core.FloatData
 
 /**
  * The basic interface for all models which defines the basic functions required for inference tasks only.
@@ -18,7 +20,7 @@ public interface InferenceModel : AutoCloseable {
      * @param [inputData] The single example with unknown label.
      * @return Predicted class index.
      */
-    public fun predict(inputData: FloatArray): Int
+    public fun predict(inputData: FloatData): Int
 
     /**
      * Predicts vector of probabilities instead of specific class in [predict] method.
@@ -27,7 +29,7 @@ public interface InferenceModel : AutoCloseable {
      * @param [predictionTensorName] The name of prediction tensor. It could be changed, if you need to get alternative outputs from model graph.
      * @return Vector that represents the probability distributions of a list of potential outcomes
      */
-    public fun predictSoftly(inputData: FloatArray, predictionTensorName: String = ""): FloatArray
+    public fun predictSoftly(inputData: FloatData, predictionTensorName: String = ""): FloatArray
 
     /**
      * Chain-like setter to set up input shape.

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/InferenceModel.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/InferenceModel.kt
@@ -32,13 +32,6 @@ public interface InferenceModel : AutoCloseable {
     public fun predictSoftly(inputData: FloatData, predictionTensorName: String = ""): FloatArray
 
     /**
-     * Chain-like setter to set up input shape.
-     *
-     * @param [dims] The input shape.
-     */
-    public fun reshape(vararg dims: Long)
-
-    /**
      * Creates a copy of this model.
      *
      * @return A copied inference model.

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataBatch.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataBatch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -9,17 +9,18 @@ package org.jetbrains.kotlinx.dl.dataset
  * This class represents the batch of data in the [Dataset].
  * @param [x] Data observations.
  * @param [y] Labels.
- * @param [size] Number of rows in batch.
  */
-public data class DataBatch internal constructor(
-    val x: Array<FloatArray>,
-    val y: FloatArray,
-    val size: Int
-) {
+public data class DataBatch internal constructor(val x: Array<FloatArray>, val y: FloatArray) {
     /**
-     * Returns 2-dimensional shape of the data batch.
+     * Number of rows in the batch.
      */
-    public fun shape(elementSize: Int): List<Long> = listOf(size.toLong(), elementSize.toLong())
+    public val size: Int get() = x.size
+
+    init {
+        check(x.size == y.size) {
+            "Number of data elements in the batch (${x.size}) is not the same as the number of labels (${y.size})."
+        }
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -27,15 +28,12 @@ public data class DataBatch internal constructor(
 
         other as DataBatch
 
-        if (!x.contentDeepEquals(other.x)) return false
-        if (!y.contentEquals(other.y)) return false
-        return size == other.size
+        return x.contentDeepEquals(other.x) && y.contentEquals(other.y)
     }
 
     override fun hashCode(): Int {
         var result = x.contentDeepHashCode()
         result = 31 * result + y.contentHashCode()
-        result = 31 * result + size
         return result
     }
 }

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataBatch.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataBatch.kt
@@ -19,6 +19,11 @@ public data class DataBatch internal constructor(val x: Array<FloatArray>, val e
      */
     public val size: Int get() = x.size
 
+    /**
+     * Shape of this [DataBatch].
+     */
+    public val shape: TensorShape get() = TensorShape(size.toLong(), *elementShape.dims())
+
     init {
         check(x.size == y.size) {
             "Number of data elements in the batch (${x.size}) is not the same as the number of labels (${y.size})."

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataBatch.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataBatch.kt
@@ -5,12 +5,15 @@
 
 package org.jetbrains.kotlinx.dl.dataset
 
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+
 /**
  * This class represents the batch of data in the [Dataset].
  * @param [x] Data observations.
  * @param [y] Labels.
+ * @param [elementShape] Shape of the data elements.
  */
-public data class DataBatch internal constructor(val x: Array<FloatArray>, val y: FloatArray) {
+public data class DataBatch internal constructor(val x: Array<FloatArray>, val elementShape: TensorShape, val y: FloatArray) {
     /**
      * Number of rows in the batch.
      */

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataLoader.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/DataLoader.kt
@@ -1,12 +1,12 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
 package org.jetbrains.kotlinx.dl.dataset
 
 import org.jetbrains.kotlinx.dl.api.core.FloatData
-import org.jetbrains.kotlinx.dl.api.core.floats
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 
 /**
  * And interface for loading data from the provided data source.
@@ -19,8 +19,23 @@ public interface DataLoader<D> {
     public fun load(dataSource: D): FloatData
 
     public companion object {
-        internal fun <D> DataLoader<D>.prepareX(sources: Array<D>): Array<FloatArray> {
-            return Array(sources.size) { load(sources[it]).floats }
+        internal fun <D> DataLoader<D>.prepareX(sources: Array<D>): Pair<Array<FloatArray>, TensorShape> {
+            return prepareX(sources, 0, sources.size)
+        }
+
+        internal fun <D> DataLoader<D>.prepareX(src: Array<D>, start: Int, length: Int): Pair<Array<FloatArray>, TensorShape> {
+            if (length == 0) return emptyArray<FloatArray>() to TensorShape()
+
+            val shapes = mutableSetOf<TensorShape>()
+            val array = Array(length) { index ->
+                val (floats, shape) = load(src[start + index])
+                shapes.add(shape)
+                floats
+            }
+            require(shapes.size == 1) {
+                "Dataset elements should have the same shape. Current shapes: $shapes"
+            }
+            return array to shapes.single()
         }
     }
 }

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/Dataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/Dataset.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.dataset
 
+import org.jetbrains.kotlinx.dl.api.core.FloatData
 import kotlin.math.min
 
 /** Just abstract Dataset. */
@@ -16,7 +17,7 @@ public abstract class Dataset {
     public abstract fun xSize(): Int
 
     /** Returns row by index [idx]. */
-    public abstract fun getX(idx: Int): FloatArray
+    public abstract fun getX(idx: Int): FloatData
 
     /** Returns label as [Int] by index [idx]. */
     public abstract fun getY(idx: Int): Float

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/InferenceModelExtensions.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/InferenceModelExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -19,7 +19,7 @@ public fun InferenceModel.predict(dataset: Dataset): List<Int> {
     val predictedLabels: MutableList<Int> = mutableListOf()
 
     for (i in 0 until dataset.xSize()) {
-        val predictedLabel = predict(dataset.getX(i).first)
+        val predictedLabel = predict(dataset.getX(i))
         predictedLabels.add(predictedLabel)
     }
 
@@ -38,7 +38,7 @@ public fun InferenceModel.evaluate(
     return if (metric == Metrics.ACCURACY) {
         var counter = 0
         for (i in 0 until dataset.xSize()) {
-            val predictedLabel = predict(dataset.getX(i).first)
+            val predictedLabel = predict(dataset.getX(i))
             if (predictedLabel == dataset.getY(i).toInt())
                 counter++
         }

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/InferenceModelExtensions.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/InferenceModelExtensions.kt
@@ -19,7 +19,7 @@ public fun InferenceModel.predict(dataset: Dataset): List<Int> {
     val predictedLabels: MutableList<Int> = mutableListOf()
 
     for (i in 0 until dataset.xSize()) {
-        val predictedLabel = predict(dataset.getX(i))
+        val predictedLabel = predict(dataset.getX(i).first)
         predictedLabels.add(predictedLabel)
     }
 
@@ -38,7 +38,7 @@ public fun InferenceModel.evaluate(
     return if (metric == Metrics.ACCURACY) {
         var counter = 0
         for (i in 0 until dataset.xSize()) {
-            val predictedLabel = predict(dataset.getX(i))
+            val predictedLabel = predict(dataset.getX(i).first)
             if (predictedLabel == dataset.getY(i).toInt())
                 counter++
         }

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
@@ -69,8 +69,8 @@ public class OnFlyImageDataset<D> internal constructor(
     }
 
     /** Returns row by index [idx]. */
-    override fun getX(idx: Int): FloatArray {
-        return dataLoader.load(x[idx]).first
+    override fun getX(idx: Int): FloatData {
+        return dataLoader.load(x[idx])
     }
 
     /** Returns label as [FloatArray] by index [idx]. */

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
@@ -85,8 +85,7 @@ public class OnFlyImageDataset<D> internal constructor(
     override fun createDataBatch(batchStart: Int, batchLength: Int): DataBatch {
         return DataBatch(
             copySourcesToBatch(x, batchStart, batchLength),
-            copyLabelsToBatch(y, batchStart, batchLength),
-            batchLength
+            copyLabelsToBatch(y, batchStart, batchLength)
         )
     }
 

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
@@ -1,12 +1,14 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
 package org.jetbrains.kotlinx.dl.dataset
 
 import org.jetbrains.kotlinx.dl.api.core.FloatData
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.preprocessing.Operation
+import org.jetbrains.kotlinx.dl.dataset.DataLoader.Companion.prepareX
 import org.jetbrains.kotlinx.dl.dataset.generator.LabelGenerator
 import org.jetbrains.kotlinx.dl.dataset.generator.LabelGenerator.Companion.prepareY
 import org.jetbrains.kotlinx.dl.dataset.preprocessing.fileLoader
@@ -32,8 +34,8 @@ public class OnFlyImageDataset<D> internal constructor(
 ) : Dataset() {
 
     /** Converts [src] to [FloatBuffer] from [start] position for the next [length] positions. */
-    private fun copySourcesToBatch(src: Array<D>, start: Int, length: Int): Array<FloatArray> {
-        return Array(length) { index -> dataLoader.load(src[start + index]).first }
+    private fun copySourcesToBatch(src: Array<D>, start: Int, length: Int): Pair<Array<FloatArray>, TensorShape> {
+        return dataLoader.prepareX(src, start, length)
     }
 
     /** Converts [src] to [FloatBuffer] from [start] position for the next [length] positions. */
@@ -83,10 +85,8 @@ public class OnFlyImageDataset<D> internal constructor(
     }
 
     override fun createDataBatch(batchStart: Int, batchLength: Int): DataBatch {
-        return DataBatch(
-            copySourcesToBatch(x, batchStart, batchLength),
-            copyLabelsToBatch(y, batchStart, batchLength)
-        )
+        val (data, shape) = copySourcesToBatch(x, batchStart, batchLength)
+        return DataBatch(data, shape, copyLabelsToBatch(y, batchStart, batchLength))
     }
 
     public companion object {

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -34,6 +34,12 @@ import kotlin.streams.toList
  * @property [y] an array of labels
  */
 public class OnHeapDataset internal constructor(public val x: Array<FloatArray>, public val y: FloatArray) : Dataset() {
+
+    init {
+        check(x.size == y.size) {
+            "Number of data elements in the dataset (${x.size}) is not the same as the number of labels (${y.size})."
+        }
+    }
 
     /** Converts [src] to [FloatBuffer] from [start] position for the next [length] positions. */
     private fun copyXToBatch(src: Array<FloatArray>, start: Int, length: Int): Array<FloatArray> {
@@ -108,75 +114,10 @@ public class OnHeapDataset internal constructor(public val x: Array<FloatArray>,
         }
 
         /**
-         * Takes data located in [trainFeaturesPath], [trainLabelsPath], [testFeaturesPath], [testLabelsPath],
-         * extracts data and labels via [featuresExtractor] and [labelExtractor]
-         * to create a pair of [OnHeapDataset] for training and testing.
+         * Creates an [OnHeapDataset] from [features] and [labels].
          */
         @JvmStatic
-        public fun createTrainAndTestDatasets(
-            trainFeaturesPath: String,
-            trainLabelsPath: String,
-            testFeaturesPath: String,
-            testLabelsPath: String,
-            featuresExtractor: (String) -> Array<FloatArray>,
-            labelExtractor: (String) -> FloatArray
-        ): Pair<OnHeapDataset, OnHeapDataset> {
-            val xTrain = featuresExtractor(trainFeaturesPath)
-            val yTrain = labelExtractor(trainLabelsPath)
-            val xTest = featuresExtractor(testFeaturesPath)
-            val yTest = labelExtractor(testLabelsPath)
-            return OnHeapDataset(xTrain, yTrain) to OnHeapDataset(xTest, yTest)
-        }
-
-        /**
-         * Takes data located in [featuresPath], [labelsPath]
-         * with [numClasses], extracts data and labels via [featuresExtractor] and [labelExtractor]
-         * to create an [OnHeapDataset].
-         */
-        @JvmStatic
-        public fun create(
-            featuresPath: String,
-            labelsPath: String,
-            numClasses: Int,
-            featuresExtractor: (String) -> Array<FloatArray>,
-            labelExtractor: (String, Int) -> FloatArray
-        ): OnHeapDataset {
-            val features = featuresExtractor(featuresPath)
-            val labels = labelExtractor(labelsPath, numClasses)
-
-            check(features.size == labels.size) { "The amount of labels is not equal to the amount of images." }
-
-            return OnHeapDataset(features, labels)
-        }
-
-        /**
-         * Takes the data from generators [featuresGenerator] and [labelGenerator]
-         * to create an [OnHeapDataset].
-         */
-        @JvmStatic
-        public fun create(
-            featuresGenerator: () -> Array<FloatArray>,
-            labelGenerator: () -> FloatArray
-        ): OnHeapDataset {
-            val features = featuresGenerator()
-            val labels = labelGenerator()
-
-            check(features.size == labels.size) { "The amount of labels is not equal to the amount of images." }
-
-            return OnHeapDataset(features, labels)
-        }
-
-        /**
-         * Takes data from external data [features] and [labels]
-         * to create dataset [OnHeapDataset].
-         */
-        @JvmStatic
-        public fun create(
-            features: Array<FloatArray>,
-            labels: FloatArray
-        ): OnHeapDataset {
-            check(features.size == labels.size) { "The amount of labels is not equal to the amount of images." }
-
+        public fun create(features: Array<FloatArray>, labels: FloatArray): OnHeapDataset {
             return OnHeapDataset(features, labels)
         }
 

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
@@ -88,8 +88,7 @@ public class OnHeapDataset internal constructor(public val x: Array<FloatArray>,
     override fun createDataBatch(batchStart: Int, batchLength: Int): DataBatch {
         return DataBatch(
             copyXToBatch(x, batchStart, batchLength),
-            copyLabelsToBatch(y, batchStart, batchLength),
-            batchLength
+            copyLabelsToBatch(y, batchStart, batchLength)
         )
     }
 

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
@@ -80,8 +80,8 @@ public class OnHeapDataset internal constructor(public val x: Array<FloatArray>,
     }
 
     /** Returns row by index [idx]. */
-    override fun getX(idx: Int): FloatArray {
-        return x[idx]
+    override fun getX(idx: Int): FloatData {
+        return x[idx] to elementShape
     }
 
     /** Returns label as [FloatArray] by index [idx]. */

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/embedded/embeddedDatasets.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/embedded/embeddedDatasets.kt
@@ -38,20 +38,10 @@ import java.util.zip.ZipFile
  * (num_samples, 28, 28). Y data uint8 arrays of digit labels (integers in range 0-9) with shapes (num_samples,).
  */
 public fun mnist(cacheDirectory: File = File("cache")): Pair<OnHeapDataset, OnHeapDataset> {
-    cacheDirectory.existsOrMkdirs()
-
-    val trainXpath = loadFile(cacheDirectory, TRAIN_IMAGES_ARCHIVE).absolutePath
-    val trainYpath = loadFile(cacheDirectory, TRAIN_LABELS_ARCHIVE).absolutePath
-    val testXpath = loadFile(cacheDirectory, TEST_IMAGES_ARCHIVE).absolutePath
-    val testYpath = loadFile(cacheDirectory, TEST_LABELS_ARCHIVE).absolutePath
-
-    return OnHeapDataset.createTrainAndTestDatasets(
-        trainXpath,
-        trainYpath,
-        testXpath,
-        testYpath,
-        ::extractImages,
-        ::extractLabels
+    return createDataset(
+        cacheDirectory,
+        TRAIN_IMAGES_ARCHIVE, TRAIN_LABELS_ARCHIVE,
+        TEST_IMAGES_ARCHIVE, TEST_LABELS_ARCHIVE
     )
 }
 
@@ -84,21 +74,27 @@ public fun mnist(cacheDirectory: File = File("cache")): Pair<OnHeapDataset, OnHe
  * (num_samples, 28, 28). Y data uint8 arrays of digit labels (integers in range 0-9) with shapes (num_samples,).
  */
 public fun fashionMnist(cacheDirectory: File = File("cache")): Pair<OnHeapDataset, OnHeapDataset> {
+    return createDataset(
+        cacheDirectory,
+        FASHION_TRAIN_IMAGES_ARCHIVE, FASHION_TRAIN_LABELS_ARCHIVE,
+        FASHION_TEST_IMAGES_ARCHIVE, FASHION_TEST_LABELS_ARCHIVE
+    )
+}
+
+private fun createDataset(cacheDirectory: File,
+                          trainImagesArchive: String, trainLabelsArchive: String,
+                          testImagesArchive: String, testLabelsArchive: String
+): Pair<OnHeapDataset, OnHeapDataset> {
     cacheDirectory.existsOrMkdirs()
 
-    val trainXpath = loadFile(cacheDirectory, FASHION_TRAIN_IMAGES_ARCHIVE).absolutePath
-    val trainYpath = loadFile(cacheDirectory, FASHION_TRAIN_LABELS_ARCHIVE).absolutePath
-    val testXpath = loadFile(cacheDirectory, FASHION_TEST_IMAGES_ARCHIVE).absolutePath
-    val testYpath = loadFile(cacheDirectory, FASHION_TEST_LABELS_ARCHIVE).absolutePath
+    val trainXpath = loadFile(cacheDirectory, trainImagesArchive).absolutePath
+    val trainYpath = loadFile(cacheDirectory, trainLabelsArchive).absolutePath
+    val testXpath = loadFile(cacheDirectory, testImagesArchive).absolutePath
+    val testYpath = loadFile(cacheDirectory, testLabelsArchive).absolutePath
 
-    return OnHeapDataset.createTrainAndTestDatasets(
-        trainXpath,
-        trainYpath,
-        testXpath,
-        testYpath,
-        ::extractImages,
-        ::extractLabels
-    )
+    val train = OnHeapDataset.create(extractImages(trainXpath), extractLabels(trainYpath))
+    val test = OnHeapDataset.create(extractImages(testXpath), extractLabels(testYpath))
+    return train to test
 }
 
 /** Path to H5 file of Mnist 3D Dataset. */

--- a/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/embedded/embeddedDatasets.kt
+++ b/dataset/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/dataset/embedded/embeddedDatasets.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -7,6 +7,7 @@ package org.jetbrains.kotlinx.dl.dataset.embedded
 
 import io.jhdf.HdfFile
 import io.jhdf.api.Dataset
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.inference.loaders.AWS_S3_URL
 import org.jetbrains.kotlinx.dl.api.inference.loaders.LoadingMode
 import org.jetbrains.kotlinx.dl.dataset.OnHeapDataset
@@ -85,6 +86,8 @@ private fun createDataset(cacheDirectory: File,
                           trainImagesArchive: String, trainLabelsArchive: String,
                           testImagesArchive: String, testLabelsArchive: String
 ): Pair<OnHeapDataset, OnHeapDataset> {
+    val shape = TensorShape(28, 28, 1)
+
     cacheDirectory.existsOrMkdirs()
 
     val trainXpath = loadFile(cacheDirectory, trainImagesArchive).absolutePath
@@ -92,8 +95,8 @@ private fun createDataset(cacheDirectory: File,
     val testXpath = loadFile(cacheDirectory, testImagesArchive).absolutePath
     val testYpath = loadFile(cacheDirectory, testLabelsArchive).absolutePath
 
-    val train = OnHeapDataset.create(extractImages(trainXpath), extractLabels(trainYpath))
-    val test = OnHeapDataset.create(extractImages(testXpath), extractLabels(testYpath))
+    val train = OnHeapDataset.create(extractImages(trainXpath), extractLabels(trainYpath), shape)
+    val test = OnHeapDataset.create(extractImages(testXpath), extractLabels(testYpath), shape)
     return train to test
 }
 
@@ -125,10 +128,11 @@ public fun mnist3D(cacheDirectory: File = File("cache")): Pair<OnHeapDataset, On
 
         val (trainData, trainLabels) = it.extractMnist3DDataset("train")
         val (testData, testLabels) = it.extractMnist3DDataset("test")
+        val shape = TensorShape(16, 16, 16)
 
         Pair(
-            OnHeapDataset.create(trainData, trainLabels),
-            OnHeapDataset.create(testData, testLabels)
+            OnHeapDataset.create(trainData, trainLabels, shape),
+            OnHeapDataset.create(testData, testLabels, shape)
         )
     }
 }
@@ -194,9 +198,11 @@ public fun freeSpokenDigits(
     val (trainData, testData) = data.splitToTrainAndTestByIndex(maxTestIndex)
     val (trainLabels, testLabels) = labels.splitToTrainAndTestByIndex(maxTestIndex)
 
+    val shape = TensorShape(FSDD_SOUND_DATA_SIZE, 1)
+
     return Pair(
-        OnHeapDataset.create(trainData, trainLabels.toFloatArray()),
-        OnHeapDataset.create(testData, testLabels.toFloatArray())
+        OnHeapDataset.create(trainData, trainLabels.toFloatArray(), shape),
+        OnHeapDataset.create(testData, testLabels.toFloatArray(), shape)
     )
 }
 

--- a/examples/src/main/kotlin/examples/cnn/mnist/DenseOnly.kt
+++ b/examples/src/main/kotlin/examples/cnn/mnist/DenseOnly.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -11,6 +11,7 @@ import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
 import org.jetbrains.kotlinx.dl.api.core.initializer.Zeros
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.layer.reshaping.Reshape
 import org.jetbrains.kotlinx.dl.api.core.loss.Losses
 import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
 import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
@@ -25,7 +26,8 @@ private const val TRAINING_BATCH_SIZE = 500
  * This is a simple model based on Dense layers only.
  */
 private val model = Sequential.of(
-    Input(784),
+    Input(28, 28, 1),
+    Reshape(listOf(784)),
     Dense(1024, Activations.Relu, kernelInitializer = HeNormal(SEED), biasInitializer = Zeros()),
     Dense(1024, Activations.Relu, kernelInitializer = HeNormal(SEED), biasInitializer = Zeros()),
     Dense(1024, Activations.Relu, kernelInitializer = HeNormal(SEED), biasInitializer = Zeros()),

--- a/examples/src/main/kotlin/examples/inference/cifar10/VGG11ExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/cifar10/VGG11ExportImport.kt
@@ -212,7 +212,7 @@ fun vgg11OnCifar10ExportImport() {
         var accuracy = 0.0
         val amountOfTestSet = test.xSize()
         for (imageId in 0 until amountOfTestSet) {
-            val prediction = it.predict(test.getX(imageId))
+            val prediction = it.predict(test.getX(imageId).first)
 
             if (prediction == test.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/cifar10/VGG11ExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/cifar10/VGG11ExportImport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -212,7 +212,7 @@ fun vgg11OnCifar10ExportImport() {
         var accuracy = 0.0
         val amountOfTestSet = test.xSize()
         for (imageId in 0 until amountOfTestSet) {
-            val prediction = it.predict(test.getX(imageId).first)
+            val prediction = it.predict(test.getX(imageId))
 
             if (prediction == test.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/cifar10/VGG11ExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/cifar10/VGG11ExportImport.kt
@@ -207,8 +207,6 @@ fun vgg11OnCifar10ExportImport() {
     val inferenceModel = TensorFlowInferenceModel.load(File(PATH_TO_MODEL))
 
     inferenceModel.use {
-        it.reshape(IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
-
         var accuracy = 0.0
         val amountOfTestSet = test.xSize()
         for (imageId in 0 until amountOfTestSet) {

--- a/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistExportImport.kt
@@ -58,7 +58,7 @@ fun lenetOnFashionMnistExportImportToTxt() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId))
+            val prediction = it.predict(train.getX(imageId).first)
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistExportImport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -58,7 +58,7 @@ fun lenetOnFashionMnistExportImportToTxt() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId).first)
+            val prediction = it.predict(train.getX(imageId))
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistExportImport.kt
@@ -53,8 +53,6 @@ fun lenetOnFashionMnistExportImportToTxt() {
     val inferenceModel = TensorFlowInferenceModel.load(File(PATH_TO_MODEL), loadOptimizerState = true)
 
     inferenceModel.use {
-        it.reshape(28, 28, 1)
-
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {

--- a/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistImport.kt
+++ b/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistImport.kt
@@ -27,7 +27,7 @@ fun main() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId))
+            val prediction = it.predict(train.getX(imageId).first)
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)
@@ -37,7 +37,7 @@ fun main() {
         val amountOfOps = 1000
         val start = System.currentTimeMillis()
         for (i in 0..amountOfOps) {
-            it.predict(train.getX(i % 50000))
+            it.predict(train.getX(i % 50000).first)
         }
         println("Time, s: ${(System.currentTimeMillis() - start) / 1000f}")
         println("Throughput, op/s: ${amountOfOps / ((System.currentTimeMillis() - start) / 1000f)}")

--- a/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistImport.kt
+++ b/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistImport.kt
@@ -22,8 +22,6 @@ fun main() {
     val inferenceModel = TensorFlowInferenceModel.load(File(PATH_TO_MODEL), loadOptimizerState = true)
 
     inferenceModel.use {
-        it.reshape(28, 28, 1)
-
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {

--- a/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistImport.kt
+++ b/examples/src/main/kotlin/examples/inference/fashionmnist/LeNetFashionMnistImport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -27,7 +27,7 @@ fun main() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId).first)
+            val prediction = it.predict(train.getX(imageId))
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)
@@ -37,7 +37,7 @@ fun main() {
         val amountOfOps = 1000
         val start = System.currentTimeMillis()
         for (i in 0..amountOfOps) {
-            it.predict(train.getX(i % 50000).first)
+            it.predict(train.getX(i % 50000))
         }
         println("Time, s: ${(System.currentTimeMillis() - start) / 1000f}")
         println("Throughput, op/s: ${amountOfOps / ((System.currentTimeMillis() - start) / 1000f)}")

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistExportImport.kt
@@ -76,8 +76,6 @@ fun lenetOnMnistDatasetExportImportToTxt() {
     val inferenceModel = TensorFlowInferenceModel.load(File(PATH_TO_MODEL), loadOptimizerState = true)
 
     inferenceModel.use {
-        it.reshape(*lenet5.inputDimensions)
-
         val prediction = it.predict(train.getX(imageId1))
 
         println("Prediction: $prediction Ground Truth: ${train.getY(imageId1)}")

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistExportImport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -57,15 +57,15 @@ fun lenetOnMnistDatasetExportImportToTxt() {
 
         it.save(File(PATH_TO_MODEL), writingMode = WritingMode.OVERRIDE)
 
-        val prediction = it.predict(train.getX(imageId1).first)
+        val prediction = it.predict(train.getX(imageId1))
 
         println("Prediction: $prediction Ground Truth: ${train.getY(imageId1)}")
 
-        val prediction2 = it.predict(train.getX(imageId2).first)
+        val prediction2 = it.predict(train.getX(imageId2))
 
         println("Prediction: $prediction2 Ground Truth: ${train.getY(imageId2)}")
 
-        val prediction3 = it.predict(train.getX(imageId3).first)
+        val prediction3 = it.predict(train.getX(imageId3))
 
         println("Prediction: $prediction3 Ground Truth: ${train.getY(imageId3)}")
 
@@ -78,22 +78,22 @@ fun lenetOnMnistDatasetExportImportToTxt() {
     inferenceModel.use {
         it.reshape(*lenet5.inputDimensions)
 
-        val prediction = it.predict(train.getX(imageId1).first)
+        val prediction = it.predict(train.getX(imageId1))
 
         println("Prediction: $prediction Ground Truth: ${train.getY(imageId1)}")
 
-        val prediction2 = it.predict(train.getX(imageId2).first)
+        val prediction2 = it.predict(train.getX(imageId2))
 
         println("Prediction: $prediction2 Ground Truth: ${train.getY(imageId2)}")
 
-        val prediction3 = it.predict(train.getX(imageId3).first)
+        val prediction3 = it.predict(train.getX(imageId3))
 
         println("Prediction: $prediction3 Ground Truth: ${train.getY(imageId3)}")
 
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val pred = it.predict(train.getX(imageId).first)
+            val pred = it.predict(train.getX(imageId))
 
             if (pred == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistExportImport.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistExportImport.kt
@@ -57,15 +57,15 @@ fun lenetOnMnistDatasetExportImportToTxt() {
 
         it.save(File(PATH_TO_MODEL), writingMode = WritingMode.OVERRIDE)
 
-        val prediction = it.predict(train.getX(imageId1))
+        val prediction = it.predict(train.getX(imageId1).first)
 
         println("Prediction: $prediction Ground Truth: ${train.getY(imageId1)}")
 
-        val prediction2 = it.predict(train.getX(imageId2))
+        val prediction2 = it.predict(train.getX(imageId2).first)
 
         println("Prediction: $prediction2 Ground Truth: ${train.getY(imageId2)}")
 
-        val prediction3 = it.predict(train.getX(imageId3))
+        val prediction3 = it.predict(train.getX(imageId3).first)
 
         println("Prediction: $prediction3 Ground Truth: ${train.getY(imageId3)}")
 
@@ -78,22 +78,22 @@ fun lenetOnMnistDatasetExportImportToTxt() {
     inferenceModel.use {
         it.reshape(*lenet5.inputDimensions)
 
-        val prediction = it.predict(train.getX(imageId1))
+        val prediction = it.predict(train.getX(imageId1).first)
 
         println("Prediction: $prediction Ground Truth: ${train.getY(imageId1)}")
 
-        val prediction2 = it.predict(train.getX(imageId2))
+        val prediction2 = it.predict(train.getX(imageId2).first)
 
         println("Prediction: $prediction2 Ground Truth: ${train.getY(imageId2)}")
 
-        val prediction3 = it.predict(train.getX(imageId3))
+        val prediction3 = it.predict(train.getX(imageId3).first)
 
         println("Prediction: $prediction3 Ground Truth: ${train.getY(imageId3)}")
 
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val pred = it.predict(train.getX(imageId))
+            val pred = it.predict(train.getX(imageId).first)
 
             if (pred == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImport.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImport.kt
@@ -22,8 +22,6 @@ fun main() {
     val inferenceModel = TensorFlowInferenceModel.load(File(PATH_TO_MODEL), loadOptimizerState = true)
 
     inferenceModel.use {
-        it.reshape(28, 28, 1)
-
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImport.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImport.kt
@@ -27,7 +27,7 @@ fun main() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId))
+            val prediction = it.predict(train.getX(imageId).first)
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImport.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -27,7 +27,7 @@ fun main() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId).first)
+            val prediction = it.predict(train.getX(imageId))
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImportAndCopy.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImportAndCopy.kt
@@ -28,8 +28,6 @@ fun main() {
     var copiedInferenceModel: TensorFlowInferenceModel
 
     inferenceModel.use {
-        it.reshape(28, 28, 1)
-
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImportAndCopy.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImportAndCopy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -33,7 +33,7 @@ fun main() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId).first)
+            val prediction = it.predict(train.getX(imageId))
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)
@@ -48,7 +48,7 @@ fun main() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId).first)
+            val prediction = it.predict(train.getX(imageId))
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImportAndCopy.kt
+++ b/examples/src/main/kotlin/examples/inference/mnist/LeNetMnistImportAndCopy.kt
@@ -33,7 +33,7 @@ fun main() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId))
+            val prediction = it.predict(train.getX(imageId).first)
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)
@@ -48,7 +48,7 @@ fun main() {
         var accuracy = 0.0
         val amountOfTestSet = 10000
         for (imageId in 0..amountOfTestSet) {
-            val prediction = it.predict(train.getX(imageId))
+            val prediction = it.predict(train.getX(imageId).first)
 
             if (prediction == train.getY(imageId).toInt())
                 accuracy += (1.0 / amountOfTestSet)

--- a/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInference.kt
+++ b/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInference.kt
@@ -26,7 +26,7 @@ fun lenetOnMnistInference() {
 
         it.reshape(28, 28, 1)
 
-        val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
+        val prediction = it.predict(train.getX(0).first, "Placeholder", "ArgMax")
 
         println("Predicted Label is: $prediction")
         println("Correct Label is: " + train.getY(0))

--- a/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInference.kt
+++ b/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInference.kt
@@ -24,8 +24,6 @@ fun lenetOnMnistInference() {
     SavedModel.load(PATH_TO_MODEL).use {
         println(it.graphToString())
 
-        it.reshape(28, 28, 1)
-
         val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
 
         println("Predicted Label is: $prediction")

--- a/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInference.kt
+++ b/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInference.kt
@@ -26,7 +26,7 @@ fun lenetOnMnistInference() {
 
         it.reshape(28, 28, 1)
 
-        val prediction = it.predict(train.getX(0).first, "Placeholder", "ArgMax")
+        val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
 
         println("Predicted Label is: $prediction")
         println("Correct Label is: " + train.getY(0))

--- a/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInferenceWithTensorNames.kt
+++ b/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInferenceWithTensorNames.kt
@@ -23,8 +23,6 @@ fun lenetOnMnistInferenceWithTensorNames() {
     SavedModel.load(PATH_TO_MODEL).use {
         println(it.graphToString())
 
-        it.reshape(28, 28, 1)
-
         val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
 
         println("Predicted Label is: $prediction")

--- a/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInferenceWithTensorNames.kt
+++ b/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInferenceWithTensorNames.kt
@@ -25,7 +25,7 @@ fun lenetOnMnistInferenceWithTensorNames() {
 
         it.reshape(28, 28, 1)
 
-        val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
+        val prediction = it.predict(train.getX(0).first, "Placeholder", "ArgMax")
 
         println("Predicted Label is: $prediction")
         println("Correct Label is: " + train.getY(0))

--- a/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInferenceWithTensorNames.kt
+++ b/examples/src/main/kotlin/examples/inference/savedmodel/LenetOnMnistInferenceWithTensorNames.kt
@@ -25,7 +25,7 @@ fun lenetOnMnistInferenceWithTensorNames() {
 
         it.reshape(28, 28, 1)
 
-        val prediction = it.predict(train.getX(0).first, "Placeholder", "ArgMax")
+        val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
 
         println("Predicted Label is: $prediction")
         println("Correct Label is: " + train.getY(0))

--- a/examples/src/main/kotlin/examples/ml/IrisClassification.kt
+++ b/examples/src/main/kotlin/examples/ml/IrisClassification.kt
@@ -41,10 +41,7 @@ private val model = Sequential.of(
 fun irisClassification() {
     data.shuffle()
 
-    val dataset = OnHeapDataset.create(
-        ::extractX,
-        ::extractY
-    )
+    val dataset = OnHeapDataset.create(extractX(), extractY())
 
     val (train, test) = dataset.split(0.9)
 

--- a/examples/src/main/kotlin/examples/ml/LinearRegression.kt
+++ b/examples/src/main/kotlin/examples/ml/LinearRegression.kt
@@ -75,10 +75,7 @@ fun linearRegression() {
         return labels
     }
 
-    val dataset = OnHeapDataset.create(
-        ::extractX,
-        ::extractY
-    )
+    val dataset = OnHeapDataset.create(extractX(), extractY())
 
     val (train, test) = dataset.split(0.9)
 

--- a/examples/src/main/kotlin/examples/ml/LinearRegression.kt
+++ b/examples/src/main/kotlin/examples/ml/LinearRegression.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -7,6 +7,7 @@ package examples.ml
 
 import org.jetbrains.kotlinx.dl.api.core.Sequential
 import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.floats
 import org.jetbrains.kotlinx.dl.api.core.initializer.GlorotNormal
 import org.jetbrains.kotlinx.dl.api.core.initializer.Zeros
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
@@ -91,7 +92,7 @@ fun linearRegression() {
 
 
         repeat(100) { id ->
-            val xReal = test.getX(id).first
+            val xReal = test.getX(id)
             val yReal = test.getY(id)
             val yPred = it.predictSoftly(xReal)
 
@@ -104,12 +105,12 @@ fun linearRegression() {
         println("MAE: $mae")
 
         repeat(100) { id ->
-            val xReal = test.getX(id).first
+            val xReal = test.getX(id)
             val yReal = test.getY(id)
 
             val yPred = it.predictSoftly(xReal)
 
-            println("xReal: ${xReal[0]}, yReal: $yReal, yPred: ${yPred[0]}")
+            println("xReal: ${xReal.floats[0]}, yReal: $yReal, yPred: ${yPred[0]}")
         }
     }
 }

--- a/examples/src/main/kotlin/examples/ml/LinearRegression.kt
+++ b/examples/src/main/kotlin/examples/ml/LinearRegression.kt
@@ -91,7 +91,7 @@ fun linearRegression() {
 
 
         repeat(100) { id ->
-            val xReal = test.getX(id)
+            val xReal = test.getX(id).first
             val yReal = test.getY(id)
             val yPred = it.predictSoftly(xReal)
 
@@ -104,7 +104,7 @@ fun linearRegression() {
         println("MAE: $mae")
 
         repeat(100) { id ->
-            val xReal = test.getX(id)
+            val xReal = test.getX(id).first
             val yReal = test.getY(id)
 
             val yPred = it.predictSoftly(xReal)

--- a/examples/src/main/kotlin/examples/ml/LinearRegressionWithTwoMetrics.kt
+++ b/examples/src/main/kotlin/examples/ml/LinearRegressionWithTwoMetrics.kt
@@ -92,7 +92,7 @@ fun linearRegressionWithTwoMetrics() {
 
 
         repeat(100) { id ->
-            val xReal = test.getX(id)
+            val xReal = test.getX(id).first
             val yReal = test.getY(id)
             val yPred = it.predictSoftly(xReal)
 
@@ -107,7 +107,7 @@ fun linearRegressionWithTwoMetrics() {
         println("MSE: $mse")
 
         repeat(100) { id ->
-            val xReal = test.getX(id)
+            val xReal = test.getX(id).first
             val yReal = test.getY(id)
 
             val yPred = it.predictSoftly(xReal)

--- a/examples/src/main/kotlin/examples/ml/LinearRegressionWithTwoMetrics.kt
+++ b/examples/src/main/kotlin/examples/ml/LinearRegressionWithTwoMetrics.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -7,6 +7,7 @@ package examples.ml
 
 import org.jetbrains.kotlinx.dl.api.core.Sequential
 import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.floats
 import org.jetbrains.kotlinx.dl.api.core.initializer.GlorotNormal
 import org.jetbrains.kotlinx.dl.api.core.initializer.Zeros
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
@@ -92,7 +93,7 @@ fun linearRegressionWithTwoMetrics() {
 
 
         repeat(100) { id ->
-            val xReal = test.getX(id).first
+            val xReal = test.getX(id)
             val yReal = test.getY(id)
             val yPred = it.predictSoftly(xReal)
 
@@ -107,12 +108,12 @@ fun linearRegressionWithTwoMetrics() {
         println("MSE: $mse")
 
         repeat(100) { id ->
-            val xReal = test.getX(id).first
+            val xReal = test.getX(id)
             val yReal = test.getY(id)
 
             val yPred = it.predictSoftly(xReal)
 
-            println("xReal: ${xReal[0]}, yReal: $yReal, yPred: ${yPred[0]}")
+            println("xReal: ${xReal.floats[0]}, yReal: $yReal, yPred: ${yPred[0]}")
         }
     }
 }

--- a/examples/src/main/kotlin/examples/ml/LinearRegressionWithTwoMetrics.kt
+++ b/examples/src/main/kotlin/examples/ml/LinearRegressionWithTwoMetrics.kt
@@ -76,10 +76,7 @@ fun linearRegressionWithTwoMetrics() {
         return labels
     }
 
-    val dataset = OnHeapDataset.create(
-        ::extractX,
-        ::extractY
-    )
+    val dataset = OnHeapDataset.create(extractX(), extractY())
 
     val (train, test) = dataset.split(0.9)
 

--- a/examples/src/main/kotlin/examples/ml/SineRegression.kt
+++ b/examples/src/main/kotlin/examples/ml/SineRegression.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -7,6 +7,7 @@ package examples.ml
 
 import org.jetbrains.kotlinx.dl.api.core.Sequential
 import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.floats
 import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
 import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
@@ -82,12 +83,12 @@ fun sineRegression() {
         println("Bias: " + it.getLayer("dense_3").weights["dense_3_dense_bias"].contentDeepToString())
 
         repeat(100) { id ->
-            val xReal = test.getX(id).first
+            val xReal = test.getX(id)
             val yReal = test.getY(id)
 
             val yPred = it.predictSoftly(xReal)
 
-            println("xReal: ${xReal[0]}, yReal: $yReal, yPred: ${yPred[0]}")
+            println("xReal: ${xReal.floats[0]}, yReal: $yReal, yPred: ${yPred[0]}")
         }
     }
 }

--- a/examples/src/main/kotlin/examples/ml/SineRegression.kt
+++ b/examples/src/main/kotlin/examples/ml/SineRegression.kt
@@ -82,7 +82,7 @@ fun sineRegression() {
         println("Bias: " + it.getLayer("dense_3").weights["dense_3_dense_bias"].contentDeepToString())
 
         repeat(100) { id ->
-            val xReal = test.getX(id)
+            val xReal = test.getX(id).first
             val yReal = test.getY(id)
 
             val yPred = it.predictSoftly(xReal)

--- a/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNet4Lite.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNet4Lite.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -36,7 +36,7 @@ fun efficientNet4LitePrediction() {
         val fileDataLoader = modelType.createPreprocessing(it).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNetB0.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/efficicentnet/EfficientNetB0.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -35,7 +35,7 @@ fun efficientNetB0Prediction() {
         val fileDataLoader = modelType.createPreprocessing(it).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/onnx/cv/lenet/LenetOnMnist.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/lenet/LenetOnMnist.kt
@@ -22,7 +22,7 @@ fun main() {
     model.use {
         println(it)
 
-        val prediction = it.predict(train.getX(0))
+        val prediction = it.predict(train.getX(0).first)
 
         println("Predicted Label is: $prediction")
         println("Correct Label is: " + train.getY(0))

--- a/examples/src/main/kotlin/examples/onnx/cv/lenet/LenetOnMnist.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/lenet/LenetOnMnist.kt
@@ -22,7 +22,7 @@ fun main() {
     model.use {
         println(it)
 
-        val prediction = it.predict(train.getX(0).first)
+        val prediction = it.predict(train.getX(0))
 
         println("Predicted Label is: $prediction")
         println("Correct Label is: " + train.getY(0))

--- a/examples/src/main/kotlin/examples/onnx/cv/onnxPredictionRunner.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/onnxPredictionRunner.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -25,7 +25,7 @@ fun runONNXImageRecognitionPrediction(modelType: ONNXModels.CV) {
         val fileDataLoader = modelType.createPreprocessing(model).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = model.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/onnx/cv/predictionRunner.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/predictionRunner.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -33,7 +33,7 @@ fun runImageRecognitionPrediction(
 
         val results = mutableListOf<Pair<String, Float>>()
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/onnx/cv/resnet/notop/ResNet50.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/resnet/notop/ResNet50.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -35,7 +35,7 @@ fun resnet50CustomPrediction() {
         val fileDataLoader = modelType.createPreprocessing(model).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/onnx/cv/resnet/notop/ResNet50additionalTrainingWithTensorFlow.kt
+++ b/examples/src/main/kotlin/examples/onnx/cv/resnet/notop/ResNet50additionalTrainingWithTensorFlow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -60,9 +60,8 @@ fun resnet50additionalTraining() {
 
     modelHub.loadModel(modelType).use { model ->
         println(model)
-        model.reshape(64, 64, 3)
 
-        val preprocessing = modelType.createPreprocessing(model).onnx { onnxModel = model }
+        val preprocessing = modelType.createPreprocessing(longArrayOf(64, 64, 3)).onnx { onnxModel = model }
 
         val dogsVsCatsDatasetPath = dogsCatsSmallDatasetPath()
         val dataset = OnFlyImageDataset.create(

--- a/examples/src/main/kotlin/examples/onnx/objectdetection/ssdmobile/SSDMobile.kt
+++ b/examples/src/main/kotlin/examples/onnx/objectdetection/ssdmobile/SSDMobile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -36,8 +36,8 @@ fun ssdMobile() {
 
         val fileDataLoader = pipeline<BufferedImage>()
             .resize {
-                outputHeight = it.inputDimensions[0].toInt()
-                outputWidth = it.inputDimensions[1].toInt()
+                outputHeight = 1000
+                outputWidth = 1000
             }
             .convert { colorMode = ColorMode.BGR }
             .toFloatArray { }

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet121.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet121.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -67,7 +67,7 @@ fun denseNet121Prediction() {
         val fileDataLoader = modelType.createPreprocessing(model).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
 

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet169.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet169.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -68,7 +68,7 @@ fun denseNet169Prediction() {
         val fileDataLoader = modelType.createPreprocessing(model).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
 

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet201.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/densenet/DenseNet201.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -68,7 +68,7 @@ fun denseNet201Prediction() {
         val fileDataLoader = modelType.createPreprocessing(it).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
 

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/resnet/Example_3_ResNet50_save_load_weigths_txt_format.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/resnet/Example_3_ResNet50_save_load_weigths_txt_format.kt
@@ -89,8 +89,6 @@ fun main() {
 
     inferenceModel.use {
         for (i in 1..8) {
-            it.reshape(224, 224, 3)
-
             val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/resnet/Example_3_ResNet50_save_load_weigths_txt_format.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/resnet/Example_3_ResNet50_save_load_weigths_txt_format.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -62,7 +62,7 @@ fun main() {
         it.loadWeights(hdfFile)
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
@@ -91,7 +91,7 @@ fun main() {
         for (i in 1..8) {
             it.reshape(224, 224, 3)
 
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
@@ -115,7 +115,7 @@ fun main() {
         it.loadWeights(File(PATH_TO_MODEL))
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
 

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/resnet/Example_4_ResNet50_copy_model_prediction.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/resnet/Example_4_ResNet50_copy_model_prediction.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -56,7 +56,7 @@ fun resnet50copyModelPrediction() {
         copiedModel = it.copy(copyWeights = true)
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
@@ -69,7 +69,7 @@ fun resnet50copyModelPrediction() {
 
     copiedModel.use {
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_1_VGG16_prediction.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_1_VGG16_prediction.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -56,7 +56,7 @@ fun vgg16prediction() {
         val fileDataLoader = modelType.createPreprocessing(it).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData, "Activation_predictions")
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_2_VGG16_loading_weights_from_txt_format.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_2_VGG16_loading_weights_from_txt_format.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -63,7 +63,7 @@ fun main() {
             .fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
             val res = it.predict(inputData, "Activation_predictions")
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
 

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_3_VGG16_loading_weights_from_old_keras_weight_format.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_3_VGG16_loading_weights_from_old_keras_weight_format.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -73,7 +73,7 @@ fun main() {
             .fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
             val res = it.predict(inputData, "Activation_predictions")
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
 
@@ -175,7 +175,7 @@ fun main() {
 
         for (i in 1..8) {
             val inputStream = OnHeapDataset::class.java.classLoader.getResourceAsStream("datasets/vgg/image$i.jpg")
-            val inputData = inputStreamLoader.load(inputStream).first
+            val inputData = inputStreamLoader.load(inputStream)
             val res = it.predict(inputData, "Activation_predictions")
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
 

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_4_VGG16_prediction_load_model_from_disk.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg16/Example_4_VGG16_prediction_load_model_from_disk.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -67,7 +67,7 @@ fun main() {
             .fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
             val res = it.predict(inputData, "Activation_predictions")
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
 

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_1_VGG19_prediction.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_1_VGG19_prediction.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -56,7 +56,7 @@ fun vgg19prediction() {
         val fileDataLoader = modelType.createPreprocessing(it).fileLoader()
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_2_VGG19_prediction_from_disk.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_2_VGG19_prediction_from_disk.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -68,7 +68,7 @@ fun main() {
 
         for (i in 1..8) {
             val inputStream = OnHeapDataset::class.java.classLoader.getResourceAsStream("datasets/vgg/image$i.jpg")
-            val inputData = inputStreamLoader.load(inputStream).first
+            val inputData = inputStreamLoader.load(inputStream)
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_4_VGG19_copy_model_prediction.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/modelhub/vgg19/Example_4_VGG19_copy_model_prediction.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -62,7 +62,7 @@ fun vgg19copyModelPrediction() {
         copiedModel = it.copy(copyWeights = true)
 
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")
@@ -75,7 +75,7 @@ fun vgg19copyModelPrediction() {
 
     copiedModel.use {
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/transferlearning/predictionRunner.kt
+++ b/examples/src/main/kotlin/examples/transferlearning/predictionRunner.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -55,7 +55,7 @@ fun runImageRecognitionPrediction(modelType: TFModels.CV<out GraphTrainableModel
 
         val fileDataLoader = modelType.createPreprocessing(it).fileLoader()
         for (i in 1..8) {
-            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg")).first
+            val inputData = fileDataLoader.load(getFileFromResource("datasets/vgg/image$i.jpg"))
 
             val res = it.predict(inputData)
             println("Predicted object for image$i.jpg is ${imageNetClassLabels[res]}")

--- a/examples/src/main/kotlin/examples/visualization/LeNetFashionMnistVisualization.kt
+++ b/examples/src/main/kotlin/examples/visualization/LeNetFashionMnistVisualization.kt
@@ -44,7 +44,7 @@ fun main() {
     val (newTrain, validation) = train.split(0.95)
 
     val sampleIndex = 42
-    val x = test.getX(sampleIndex)
+    val x = test.getX(sampleIndex).first
     val y = test.getY(sampleIndex).toInt()
 
     lenet5().use {

--- a/examples/src/main/kotlin/examples/visualization/LeNetFashionMnistVisualization.kt
+++ b/examples/src/main/kotlin/examples/visualization/LeNetFashionMnistVisualization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -44,7 +44,7 @@ fun main() {
     val (newTrain, validation) = train.split(0.95)
 
     val sampleIndex = 42
-    val x = test.getX(sampleIndex).first
+    val x = test.getX(sampleIndex)
     val y = test.getY(sampleIndex).toInt()
 
     lenet5().use {

--- a/examples/src/main/kotlin/examples/visualization/LeNetMnistVisualization.kt
+++ b/examples/src/main/kotlin/examples/visualization/LeNetMnistVisualization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -34,7 +34,7 @@ fun main() {
     val (train, test) = mnist()
 
     val sampleIndex = 42
-    val x = test.getX(sampleIndex).first
+    val x = test.getX(sampleIndex)
     val y = test.getY(sampleIndex).toInt()
 
     lenet5().use {

--- a/examples/src/main/kotlin/examples/visualization/LeNetMnistVisualization.kt
+++ b/examples/src/main/kotlin/examples/visualization/LeNetMnistVisualization.kt
@@ -34,7 +34,7 @@ fun main() {
     val (train, test) = mnist()
 
     val sampleIndex = 42
-    val x = test.getX(sampleIndex)
+    val x = test.getX(sampleIndex).first
     val y = test.getY(sampleIndex).toInt()
 
     lenet5().use {

--- a/examples/src/test/kotlin/examples/onnx/OnnxOutputsSupportTestSuite.kt
+++ b/examples/src/test/kotlin/examples/onnx/OnnxOutputsSupportTestSuite.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
 package examples.onnx
 
 import examples.transferlearning.getFileFromResource
@@ -20,7 +25,7 @@ class OnnxOutputsSupportTestSuite {
     @Test
     fun predictSoftlyLgbmSequenceOutputTest() {
         assertThrows<IllegalArgumentException> {
-            model.predictSoftly(features, "probabilities")
+            model.predictSoftly(features to TensorShape(27), "probabilities")
         }
     }
 

--- a/examples/src/test/kotlin/examples/onnx/OnnxOutputsSupportTestSuite.kt
+++ b/examples/src/test/kotlin/examples/onnx/OnnxOutputsSupportTestSuite.kt
@@ -18,10 +18,6 @@ class OnnxOutputsSupportTestSuite {
     private val model = OnnxInferenceModel.load(pathToModel)
     private val features = (1..27).map { Random.nextFloat() }.toFloatArray()
 
-    init {
-        model.reshape(27)
-    }
-
     @Test
     fun predictSoftlyLgbmSequenceOutputTest() {
         assertThrows<IllegalArgumentException> {

--- a/examples/src/test/kotlin/examples/onnx/objectdetection/ObjectDetectionTestSuite.kt
+++ b/examples/src/test/kotlin/examples/onnx/objectdetection/ObjectDetectionTestSuite.kt
@@ -127,8 +127,8 @@ fun efficientDetInference(modelType: ONNXModels.ObjectDetection<EfficientDetObje
     model.use {
         val fileDataLoader = pipeline<BufferedImage>()
             .resize {
-                outputHeight = it.inputDimensions[0].toInt()
-                outputWidth = it.inputDimensions[1].toInt()
+                outputHeight = 512
+                outputWidth = 512
             }
             .convert { colorMode = ColorMode.BGR }
             .toFloatArray { }

--- a/impl/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/impl/inference/imagerecognition/ImageRecognitionModelBase.kt
+++ b/impl/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/impl/inference/imagerecognition/ImageRecognitionModelBase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -43,7 +43,7 @@ public abstract class ImageRecognitionModelBase<I>(
      * @return The label of the recognized object with the highest probability.
      */
     public fun predictObject(image: I): String {
-        val (input, _) = preprocessing.apply(image)
+        val input = preprocessing.apply(image)
         return classLabels[internalModel.predict(input)]!!
     }
 
@@ -59,7 +59,7 @@ public abstract class ImageRecognitionModelBase<I>(
      * @return The list of pairs <label, probability> sorted from the most probable to the lowest probable.
      */
     public fun predictTopKObjects(image: I, topK: Int = 5): List<Pair<String, Float>> {
-        val (input, _) = preprocessing.apply(image)
+        val input = preprocessing.apply(image)
         return internalModel.predictTopNLabels(input, classLabels, topK)
     }
 

--- a/impl/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/impl/inference/imagerecognition/prediction.kt
+++ b/impl/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/impl/inference/imagerecognition/prediction.kt
@@ -1,27 +1,28 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
 package org.jetbrains.kotlinx.dl.impl.inference.imagerecognition
 
+import org.jetbrains.kotlinx.dl.api.core.FloatData
 import org.jetbrains.kotlinx.dl.api.inference.InferenceModel
 import java.util.*
 
-/** Returns top-N labels for the given [floatArray] encoded with mapping [labels]. */
+/** Returns top-N labels for the given [floatData] encoded with mapping [labels]. */
 public fun InferenceModel.predictTopNLabels(
-    floatArray: FloatArray,
+    floatData: FloatData,
     labels: Map<Int, String>,
     n: Int = 5
 ): List<Pair<String, Float>> {
-    val prediction = predictSoftly(floatArray)
+    val prediction = predictSoftly(floatData)
     val topNIndexes = prediction.indexOfMaxN(n)
     return topNIndexes.map { index -> labels[index]!! to prediction[index] }
 }
 
 /** Returns top-5 labels for the given [data] encoded with mapping [classLabels]. */
 public fun InferenceModel.predictTop5Labels(
-    data: FloatArray,
+    data: FloatData,
     classLabels: Map<Int, String>,
 ): List<Pair<String, Float>> {
     return predictTopNLabels(data, classLabels, n = 5)

--- a/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/OnnxModelHub.kt
+++ b/onnx/src/androidMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/OnnxModelHub.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -31,7 +31,6 @@ public class ONNXModelHub(private val context: Context) : ModelHub() {
         val inferenceModel = OnnxInferenceModel {
             context.resources.openRawResource(modelResourceId).use { it.readBytes() }
         }
-        modelType.inputShape?.let { shape -> inferenceModel.reshape(*shape) }
         inferenceModel.initializeWith(*executionProviders)
         return inferenceModel
     }

--- a/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/OnnxInferenceModel.kt
+++ b/onnx/src/commonMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/OnnxInferenceModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -183,11 +183,11 @@ public open class OnnxInferenceModel private constructor(
     override val inputDimensions: LongArray
         get() = TensorShape(inputShape ?: inputInfo.getShape(0)).tail()
 
-    public override fun predict(inputData: FloatArray): Int {
+    public override fun predict(inputData: FloatData): Int {
         return predictSoftly(inputData).argmax()
     }
 
-    override fun predictSoftly(inputData: FloatArray, predictionTensorName: String): FloatArray {
+    override fun predictSoftly(inputData: FloatData, predictionTensorName: String): FloatArray {
         val outputTensorName = predictionTensorName.ifEmpty { outputInfo.getName(0) }
         require(outputTensorName in outputInfo) {
             "There is no output with name '$outputTensorName'." +
@@ -197,10 +197,7 @@ public open class OnnxInferenceModel private constructor(
         val outputInfo = outputInfo.getValue(outputTensorName).info
         throwIfOutputNotSupported(outputInfo, outputTensorName, "predictSoftly", OnnxJavaType.FLOAT)
 
-        val shape = (inputShape ?: inputInfo.getShape(0)).tail()
-        val floatData = FloatData(inputData, TensorShape(shape))
-
-        return predictRaw(floatData) { output -> output.getFloatArray(outputTensorName) }
+        return predictRaw(inputData) { output -> output.getFloatArray(outputTensorName) }
     }
 
     /**

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/dataset/preprocessor/ONNXModelPreprocessor.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/dataset/preprocessor/ONNXModelPreprocessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -7,6 +7,7 @@ package org.jetbrains.kotlinx.dl.onnx.dataset.preprocessor
 
 import org.jetbrains.kotlinx.dl.api.core.FloatData
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape.Companion.tail
 import org.jetbrains.kotlinx.dl.api.preprocessing.Operation
 import org.jetbrains.kotlinx.dl.api.preprocessing.PreprocessingPipeline
 import org.jetbrains.kotlinx.dl.onnx.inference.OnnxInferenceModel
@@ -24,7 +25,7 @@ public class ONNXModelPreprocessor(public var onnxModel: OnnxInferenceModel?, pu
         val (prediction, rawShape) = onnxModel!!.predictRaw(input) { output ->
             return@predictRaw output.getFloatArrayWithShape(outputIndex)
         }
-        return prediction to TensorShape(rawShape)
+        return prediction to TensorShape(rawShape.tail())
     }
 
     override fun getOutputShape(inputShape: TensorShape): TensorShape {

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/ONNXModelHub.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/ONNXModelHub.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -85,7 +85,6 @@ public class ONNXModelHub(public val cacheDirectory: File) : ModelHub() {
     ): OnnxInferenceModel {
         val modelFile = S3_FOLDER_SEPARATOR + modelType.modelRelativePath + MODEL_FILE_EXTENSION
         val inferenceModel = OnnxInferenceModel(getONNXModelFile(modelFile, loadingMode).absolutePath)
-        modelType.inputShape?.let { shape -> inferenceModel.reshape(*shape) }
         inferenceModel.initializeWith(*executionProviders)
         return inferenceModel
     }

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/ONNXModels.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/ONNXModels.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -646,6 +646,14 @@ public object ONNXModels {
             public fun CVnoTop.createPreprocessing(model: InferenceModel): Operation<BufferedImage, FloatData> {
                 return createPreprocessing(model, channelsFirst, inputColorMode, preprocessor)
             }
+
+            /**
+             * Creates a preprocessing [Operation] which resizes given [BufferedImage] to the specified input dimensions
+             * and converts it to [FloatData].
+             */
+            public fun CVnoTop.createPreprocessing(inputDimensions: LongArray): Operation<BufferedImage, FloatData> {
+                return createPreprocessing(inputDimensions, channelsFirst, inputColorMode, preprocessor)
+            }
         }
     }
 
@@ -707,10 +715,12 @@ public object ONNXModels {
          */
         public object SSDMobileNetV1 :
             ObjectDetection<SSDMobileNetV1ObjectDetectionModel>("models/onnx/objectdetection/ssd_mobilenet_v1") {
-            override val inputShape: LongArray = longArrayOf(1000L, 1000L, 3L)
-
             override fun pretrainedModel(modelHub: ModelHub): SSDMobileNetV1ObjectDetectionModel {
-                return SSDMobileNetV1ObjectDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return SSDMobileNetV1ObjectDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(1000L, 1000L, 3L),
+                    this::class.simpleName
+                )
             }
         }
 
@@ -737,10 +747,13 @@ public object ONNXModels {
          */
         public object EfficientDetD0 :
             ObjectDetection<EfficientDetObjectDetectionModel>("models/onnx/objectdetection/efficientdet/efficientdet-d0") {
-            override val inputShape: LongArray = longArrayOf(512L, 512L, 3L)
 
             override fun pretrainedModel(modelHub: ModelHub): EfficientDetObjectDetectionModel {
-                return EfficientDetObjectDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return EfficientDetObjectDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(512L, 512L, 3L),
+                    this::class.simpleName
+                )
             }
         }
 
@@ -766,10 +779,12 @@ public object ONNXModels {
          */
         public object EfficientDetD1 :
             ObjectDetection<EfficientDetObjectDetectionModel>("models/onnx/objectdetection/efficientdet/efficientdet-d1") {
-            override val inputShape: LongArray = longArrayOf(640L, 640L, 3L)
-
             override fun pretrainedModel(modelHub: ModelHub): EfficientDetObjectDetectionModel {
-                return EfficientDetObjectDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return EfficientDetObjectDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(640L, 640L, 3L),
+                    this::class.simpleName
+                )
             }
         }
 
@@ -795,10 +810,12 @@ public object ONNXModels {
          */
         public object EfficientDetD2 :
             ObjectDetection<EfficientDetObjectDetectionModel>("models/onnx/objectdetection/efficientdet/efficientdet-d2") {
-            override val inputShape: LongArray = longArrayOf(768L, 768L, 3L)
-
             override fun pretrainedModel(modelHub: ModelHub): EfficientDetObjectDetectionModel {
-                return EfficientDetObjectDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return EfficientDetObjectDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(768L, 768L, 3L),
+                    this::class.simpleName
+                )
             }
         }
 
@@ -824,10 +841,13 @@ public object ONNXModels {
          */
         public object EfficientDetD3 :
             ObjectDetection<EfficientDetObjectDetectionModel>("models/onnx/objectdetection/efficientdet/efficientdet-d3") {
-            override val inputShape: LongArray = longArrayOf(896L, 896L, 3L)
 
             override fun pretrainedModel(modelHub: ModelHub): EfficientDetObjectDetectionModel {
-                return EfficientDetObjectDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return EfficientDetObjectDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(896L, 896L, 3L),
+                    this::class.simpleName
+                )
             }
         }
 
@@ -853,10 +873,12 @@ public object ONNXModels {
          */
         public object EfficientDetD4 :
             ObjectDetection<EfficientDetObjectDetectionModel>("models/onnx/objectdetection/efficientdet/efficientdet-d4") {
-            override val inputShape: LongArray = longArrayOf(1024L, 1024L, 3L)
-
             override fun pretrainedModel(modelHub: ModelHub): EfficientDetObjectDetectionModel {
-                return EfficientDetObjectDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return EfficientDetObjectDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(1024L, 1024L, 3L),
+                    this::class.simpleName
+                )
             }
         }
 
@@ -882,10 +904,12 @@ public object ONNXModels {
          */
         public object EfficientDetD5 :
             ObjectDetection<EfficientDetObjectDetectionModel>("models/onnx/objectdetection/efficientdet/efficientdet-d5") {
-            override val inputShape: LongArray = longArrayOf(1280L, 1280L, 3L)
-
             override fun pretrainedModel(modelHub: ModelHub): EfficientDetObjectDetectionModel {
-                return EfficientDetObjectDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return EfficientDetObjectDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(1280L, 1280L, 3L),
+                    this::class.simpleName
+                )
             }
         }
 
@@ -911,10 +935,12 @@ public object ONNXModels {
          */
         public object EfficientDetD6 :
             ObjectDetection<EfficientDetObjectDetectionModel>("models/onnx/objectdetection/efficientdet/efficientdet-d6") {
-            override val inputShape: LongArray = longArrayOf(1280L, 1280L, 3L)
-
             override fun pretrainedModel(modelHub: ModelHub): EfficientDetObjectDetectionModel {
-                return EfficientDetObjectDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return EfficientDetObjectDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(1280L, 1280L, 3L),
+                    this::class.simpleName
+                )
             }
         }
     }
@@ -1042,10 +1068,12 @@ public object ONNXModels {
          */
         public object MoveNetMultiPoseLighting :
             PoseDetection<MultiPoseDetectionModel>("models/onnx/poseestimation/movenet_multipose_lighting") {
-            override val inputShape: LongArray = longArrayOf(256L, 256L, 3L)
-
             override fun pretrainedModel(modelHub: ModelHub): MultiPoseDetectionModel {
-                return MultiPoseDetectionModel(modelHub.loadModel(this), this::class.simpleName)
+                return MultiPoseDetectionModel(
+                    modelHub.loadModel(this),
+                    longArrayOf(256L, 256L, 3L),
+                    this::class.simpleName
+                )
             }
         }
 

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/objectdetection/EfficientDetObjectDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/objectdetection/EfficientDetObjectDetectionModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -30,14 +30,15 @@ import java.io.IOException
  */
 public class EfficientDetObjectDetectionModel(
     override val internalModel: OnnxInferenceModel,
+    private var inputShape: LongArray,
     modelKindDescription: String? = null
 ) : EfficientDetObjectDetectionModelBase<BufferedImage>(modelKindDescription) {
 
     override val preprocessing: Operation<BufferedImage, FloatData>
         get() = pipeline<BufferedImage>()
             .resize {
-                outputHeight = internalModel.inputDimensions[0].toInt()
-                outputWidth = internalModel.inputDimensions[1].toInt()
+                outputHeight = inputShape[0].toInt()
+                outputWidth = inputShape[1].toInt()
             }
             // the channels of input of EfficientDet models should be in RGB order
             // model is quite sensitive for this
@@ -49,7 +50,7 @@ public class EfficientDetObjectDetectionModel(
      * Constructs the object detection model from a given path.
      * @param [pathToModel] path to model
      */
-    public constructor(pathToModel: String) : this(OnnxInferenceModel(pathToModel))
+    public constructor(pathToModel: String, inputShape: LongArray) : this(OnnxInferenceModel(pathToModel), inputShape)
 
     /**
      * Returns the detected object for the given image file sorted by the score.
@@ -70,7 +71,9 @@ public class EfficientDetObjectDetectionModel(
      *
      * @param dims The input shape.
      */
-    public fun reshape(vararg dims: Long): Unit = internalModel.reshape(*dims)
+    public fun reshape(vararg dims: Long) {
+        inputShape = longArrayOf(*dims)
+    }
 
     override fun close(): Unit = internalModel.close()
 }

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/objectdetection/SSDMobileNetV1ObjectDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/objectdetection/SSDMobileNetV1ObjectDetectionModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -39,14 +39,15 @@ private val SSD_MOBILENET_METADATA = SSDLikeModelMetadata(
  */
 public class SSDMobileNetV1ObjectDetectionModel(
     override val internalModel: OnnxInferenceModel,
+    private var inputShape: LongArray,
     modelKindDescription: String? = null
 ) : SSDLikeModelBase<BufferedImage>(SSD_MOBILENET_METADATA, modelKindDescription) {
 
     override val preprocessing: Operation<BufferedImage, FloatData>
         get() = pipeline<BufferedImage>()
             .resize {
-                outputHeight = internalModel.inputDimensions[0].toInt()
-                outputWidth = internalModel.inputDimensions[1].toInt()
+                outputHeight = inputShape[0].toInt()
+                outputWidth = inputShape[1].toInt()
             }
             .convert { colorMode = ColorMode.RGB }
             .toFloatArray { }
@@ -58,7 +59,7 @@ public class SSDMobileNetV1ObjectDetectionModel(
      * Constructs the object detection model from a given path.
      * @param [pathToModel] path to model
      */
-    public constructor(pathToModel: String) : this(OnnxInferenceModel(pathToModel))
+    public constructor(pathToModel: String, inputShape: LongArray) : this(OnnxInferenceModel(pathToModel), inputShape)
 
     /**
      * Returns the top N detected object for the given image file sorted by the score.
@@ -79,7 +80,9 @@ public class SSDMobileNetV1ObjectDetectionModel(
      *
      * @param dims The input shape.
      */
-    public fun reshape(vararg dims: Long): Unit = internalModel.reshape(*dims)
+    public fun reshape(vararg dims: Long) {
+        inputShape = longArrayOf(*dims)
+    }
 
     override fun close(): Unit = internalModel.close()
 }

--- a/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/posedetection/MultiPoseDetectionModel.kt
+++ b/onnx/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/onnx/inference/posedetection/MultiPoseDetectionModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -28,14 +28,15 @@ private const val OUTPUT_NAME = "output_0"
  */
 public class MultiPoseDetectionModel(
     override val internalModel: OnnxInferenceModel,
+    private var inputShape: LongArray,
     modelKindDescription: String? = null
 ) : MultiPoseDetectionModelBase<BufferedImage>(modelKindDescription) {
 
     override val preprocessing: Operation<BufferedImage, FloatData>
         get() = pipeline<BufferedImage>()
             .resize {
-                outputHeight = internalModel.inputDimensions[0].toInt()
-                outputWidth = internalModel.inputDimensions[1].toInt()
+                outputHeight = inputShape[0].toInt()
+                outputWidth = inputShape[1].toInt()
             }
             .convert { colorMode = ColorMode.RGB }
             .toFloatArray { }
@@ -49,7 +50,7 @@ public class MultiPoseDetectionModel(
      * Constructs the pose detection model from a given path.
      * @param [pathToModel] path to model
      */
-    public constructor(pathToModel: String) : this(OnnxInferenceModel(pathToModel))
+    public constructor(pathToModel: String, inputShape: LongArray) : this(OnnxInferenceModel(pathToModel), inputShape)
 
     /**
      * Detects poses for the given [imageFile] with the given [confidence].
@@ -65,7 +66,9 @@ public class MultiPoseDetectionModel(
      *
      * @param dims The input shape.
      */
-    public fun reshape(vararg dims: Long): Unit = internalModel.reshape(*dims)
+    public fun reshape(vararg dims: Long) {
+        inputShape = longArrayOf(*dims)
+    }
 
     override fun close(): Unit = internalModel.close()
 }

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/GraphTrainableModel.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/GraphTrainableModel.kt
@@ -126,10 +126,6 @@ public abstract class GraphTrainableModel(vararg layers: Layer) : TrainableModel
      */
     private fun frozenLayerVariables(): List<KVariable> = layers.frozenVariables()
 
-    override fun reshape(vararg dims: Long) {
-        throw UnsupportedOperationException("Reshaping model $this is not supported.")
-    }
-
     override fun compile(optimizer: Optimizer, loss: Losses, metric: Metrics) {
         compile(optimizer, Losses.convert(loss), Metric.convert(metric))
     }

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/TrainableModel.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/TrainableModel.kt
@@ -346,7 +346,7 @@ public abstract class TrainableModel : TensorFlowInferenceModelBase(), ModelWith
      * @param [inputData] Unlabeled input data to define label.
      * @param [predictionTensorName] Name of output tensor to make prediction.
      */
-    public abstract fun predict(inputData: FloatArray, predictionTensorName: String): Int
+    public abstract fun predict(inputData: FloatData, predictionTensorName: String): Int
 
     /**
      * Predicts and returns not only prediction but list of activations values from intermediate model layers
@@ -357,7 +357,7 @@ public abstract class TrainableModel : TensorFlowInferenceModelBase(), ModelWith
      * @return Label (class index) and list of activations from intermediate model layers.
      */
     public abstract fun predictAndGetActivations(
-        inputData: FloatArray,
+        inputData: FloatData,
         predictionTensorName: String = ""
     ): Pair<Int, List<*>>
 
@@ -370,7 +370,7 @@ public abstract class TrainableModel : TensorFlowInferenceModelBase(), ModelWith
      * @return Label (class index) and list of activations from intermediate model layers.
      */
     protected abstract fun predictSoftlyAndGetActivations(
-        inputData: FloatArray,
+        inputData: FloatData,
         predictionTensorName: String
     ): Pair<FloatArray, List<*>>
 

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/TensorFlowInferenceModel.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/TensorFlowInferenceModel.kt
@@ -38,10 +38,6 @@ public open class TensorFlowInferenceModel(tfGraph: Graph = Graph(),
     /** Output operand. */
     protected var output: String = OUTPUT_ARG_MAX
 
-    /** Data shape for prediction. */
-    public lateinit var shape: LongArray
-        private set
-
     override val inputDimensions: LongArray
         get() = TODO("Not yet implemented")
 
@@ -106,10 +102,6 @@ public open class TensorFlowInferenceModel(tfGraph: Graph = Graph(),
         output = outputName
     }
 
-    override fun reshape(vararg dims: Long) {
-        this.shape = TensorShape(1, *dims).dims()
-    }
-
     /** Forms the graph description in string format. */
     public fun graphToString(): String {
         return tfGraph.convertToString()
@@ -122,7 +114,6 @@ public open class TensorFlowInferenceModel(tfGraph: Graph = Graph(),
     /** Returns a copy of this model. */
     public fun copy(copiedModelName: String? = null): TensorFlowInferenceModel {
         val model = TensorFlowInferenceModel(tfGraph.copy())
-        model.shape = shape
         model.input = input
         model.output = output
         if (copiedModelName != null) model.name = name

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/savedmodel/SavedModel.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/savedmodel/SavedModel.kt
@@ -37,7 +37,7 @@ public open class SavedModel(private val bundle: SavedModelBundle) :
         val predictedLabels: MutableList<Int> = mutableListOf()
 
         for (i in 0 until dataset.xSize()) {
-            val predictedLabel = predict(dataset.getX(i).first, inputTensorName, outputTensorName)
+            val predictedLabel = predict(dataset.getX(i), inputTensorName, outputTensorName)
             predictedLabels.add(predictedLabel)
         }
 

--- a/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/savedmodel/SavedModel.kt
+++ b/tensorflow/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/savedmodel/SavedModel.kt
@@ -37,7 +37,7 @@ public open class SavedModel(private val bundle: SavedModelBundle) :
         val predictedLabels: MutableList<Int> = mutableListOf()
 
         for (i in 0 until dataset.xSize()) {
-            val predictedLabel = predict(dataset.getX(i), inputTensorName, outputTensorName)
+            val predictedLabel = predict(dataset.getX(i).first, inputTensorName, outputTensorName)
             predictedLabels.add(predictedLabel)
         }
 

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SavedModelTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SavedModelTest.kt
@@ -25,8 +25,6 @@ class SavedModelTest {
         val modelDirectory = File(PATH_TO_MODEL)
 
         SavedModel.load(modelDirectory.absolutePath).use {
-            it.reshape(28, 28, 1)
-
             val prediction = it.predict(train.getX(0))
 
             assertEquals(train.getY(0), prediction.toFloat())
@@ -45,8 +43,6 @@ class SavedModelTest {
         val modelDirectory = File(PATH_TO_MODEL)
 
         SavedModel.load(modelDirectory.absolutePath).use {
-            it.reshape(28, 28, 1)
-
             val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
 
             assertEquals(train.getY(0), prediction.toFloat())

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SavedModelTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SavedModelTest.kt
@@ -27,7 +27,7 @@ class SavedModelTest {
         SavedModel.load(modelDirectory.absolutePath).use {
             it.reshape(28, 28, 1)
 
-            val prediction = it.predict(train.getX(0))
+            val prediction = it.predict(train.getX(0).first)
 
             assertEquals(train.getY(0), prediction.toFloat())
 
@@ -47,7 +47,7 @@ class SavedModelTest {
         SavedModel.load(modelDirectory.absolutePath).use {
             it.reshape(28, 28, 1)
 
-            val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
+            val prediction = it.predict(train.getX(0).first, "Placeholder", "ArgMax")
 
             assertEquals(train.getY(0), prediction.toFloat())
 

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SavedModelTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SavedModelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -27,7 +27,7 @@ class SavedModelTest {
         SavedModel.load(modelDirectory.absolutePath).use {
             it.reshape(28, 28, 1)
 
-            val prediction = it.predict(train.getX(0).first)
+            val prediction = it.predict(train.getX(0))
 
             assertEquals(train.getY(0), prediction.toFloat())
 
@@ -47,7 +47,7 @@ class SavedModelTest {
         SavedModel.load(modelDirectory.absolutePath).use {
             it.reshape(28, 28, 1)
 
-            val prediction = it.predict(train.getX(0).first, "Placeholder", "ArgMax")
+            val prediction = it.predict(train.getX(0), "Placeholder", "ArgMax")
 
             assertEquals(train.getY(0), prediction.toFloat())
 

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SequentialBasicTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SequentialBasicTest.kt
@@ -207,10 +207,10 @@ internal class SequentialBasicTest : IntegrationTest() {
         test: OnHeapDataset
     ) {
         // Prediction testing
-        val label = it.predict(test.getX(0).first)
+        val label = it.predict(test.getX(0))
         assertEquals(test.getY(0), label.toFloat())
 
-        val softPrediction = it.predictSoftly(test.getX(0).first)
+        val softPrediction = it.predictSoftly(test.getX(0))
 
         assertEquals(
             test.getY(0),
@@ -218,11 +218,11 @@ internal class SequentialBasicTest : IntegrationTest() {
         )
 
         // Test predict method with specified tensor name
-        val label2 = it.predict(test.getX(0).first, predictionTensorName = OUTPUT_NAME)
+        val label2 = it.predict(test.getX(0), predictionTensorName = OUTPUT_NAME)
         assertEquals(test.getY(0), label2.toFloat())
 
         // Test predictAndGetActivations method
-        val (label3, activations) = it.predictAndGetActivations(test.getX(0).first)
+        val (label3, activations) = it.predictAndGetActivations(test.getX(0))
         assertEquals(test.getY(0), label3.toFloat())
         assertEquals(3, activations.size)
 
@@ -392,7 +392,7 @@ internal class SequentialBasicTest : IntegrationTest() {
         testModel.use {
             val exception =
                 assertThrows(IllegalStateException::class.java) {
-                    it.predict(train.getX(0).first)
+                    it.predict(train.getX(0))
                 }
             assertEquals(
                 "The model is not compiled yet. Compile the model to use this method.",
@@ -408,7 +408,7 @@ internal class SequentialBasicTest : IntegrationTest() {
         testModel.use {
             val exception =
                 assertThrows(IllegalStateException::class.java) {
-                    it.predictSoftly(train.getX(0).first)
+                    it.predictSoftly(train.getX(0))
                 }
             assertEquals(
                 "The model is not compiled yet. Compile the model to use this method.",
@@ -445,7 +445,7 @@ internal class SequentialBasicTest : IntegrationTest() {
         testModel.use {
             val exception =
                 assertThrows(IllegalStateException::class.java) {
-                    it.predictAndGetActivations(test.getX(0).first)
+                    it.predictAndGetActivations(test.getX(0))
                 }
             assertEquals(
                 "The model is not compiled yet. Compile the model to use this method.",

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SequentialBasicTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SequentialBasicTest.kt
@@ -207,10 +207,10 @@ internal class SequentialBasicTest : IntegrationTest() {
         test: OnHeapDataset
     ) {
         // Prediction testing
-        val label = it.predict(test.getX(0))
+        val label = it.predict(test.getX(0).first)
         assertEquals(test.getY(0), label.toFloat())
 
-        val softPrediction = it.predictSoftly(test.getX(0))
+        val softPrediction = it.predictSoftly(test.getX(0).first)
 
         assertEquals(
             test.getY(0),
@@ -218,11 +218,11 @@ internal class SequentialBasicTest : IntegrationTest() {
         )
 
         // Test predict method with specified tensor name
-        val label2 = it.predict(test.getX(0), predictionTensorName = OUTPUT_NAME)
+        val label2 = it.predict(test.getX(0).first, predictionTensorName = OUTPUT_NAME)
         assertEquals(test.getY(0), label2.toFloat())
 
         // Test predictAndGetActivations method
-        val (label3, activations) = it.predictAndGetActivations(test.getX(0))
+        val (label3, activations) = it.predictAndGetActivations(test.getX(0).first)
         assertEquals(test.getY(0), label3.toFloat())
         assertEquals(3, activations.size)
 
@@ -392,7 +392,7 @@ internal class SequentialBasicTest : IntegrationTest() {
         testModel.use {
             val exception =
                 assertThrows(IllegalStateException::class.java) {
-                    it.predict(train.getX(0))
+                    it.predict(train.getX(0).first)
                 }
             assertEquals(
                 "The model is not compiled yet. Compile the model to use this method.",
@@ -408,7 +408,7 @@ internal class SequentialBasicTest : IntegrationTest() {
         testModel.use {
             val exception =
                 assertThrows(IllegalStateException::class.java) {
-                    it.predictSoftly(train.getX(0))
+                    it.predictSoftly(train.getX(0).first)
                 }
             assertEquals(
                 "The model is not compiled yet. Compile the model to use this method.",
@@ -445,7 +445,7 @@ internal class SequentialBasicTest : IntegrationTest() {
         testModel.use {
             val exception =
                 assertThrows(IllegalStateException::class.java) {
-                    it.predictAndGetActivations(test.getX(0))
+                    it.predictAndGetActivations(test.getX(0).first)
                 }
             assertEquals(
                 "The model is not compiled yet. Compile the model to use this method.",

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SequentialInferenceTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SequentialInferenceTest.kt
@@ -258,7 +258,7 @@ class SequentialInferenceTest {
 
             val predictException =
                 Assertions.assertThrows(IllegalStateException::class.java) {
-                    it.predict(test.getX(0))
+                    it.predict(test.getX(0).first)
                 }
             assertEquals(
                 "The model is not compiled yet. Compile the model to use this method.",
@@ -296,7 +296,7 @@ class SequentialInferenceTest {
 
             val predictException =
                 Assertions.assertThrows(IllegalStateException::class.java) {
-                    it.predict(test.getX(0))
+                    it.predict(test.getX(0).first)
                 }
             assertEquals(
                 "The model is not initialized yet. Initialize the model weights with init() method or load weights to use this method.",

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SequentialInferenceTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/SequentialInferenceTest.kt
@@ -258,7 +258,7 @@ class SequentialInferenceTest {
 
             val predictException =
                 Assertions.assertThrows(IllegalStateException::class.java) {
-                    it.predict(test.getX(0).first)
+                    it.predict(test.getX(0))
                 }
             assertEquals(
                 "The model is not compiled yet. Compile the model to use this method.",
@@ -296,7 +296,7 @@ class SequentialInferenceTest {
 
             val predictException =
                 Assertions.assertThrows(IllegalStateException::class.java) {
-                    it.predict(test.getX(0).first)
+                    it.predict(test.getX(0))
                 }
             assertEquals(
                 "The model is not initialized yet. Initialize the model weights with init() method or load weights to use this method.",

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/TensorFlowInferenceModelTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/TensorFlowInferenceModelTest.kt
@@ -144,8 +144,8 @@ class TensorFlowInferenceModelTest {
             var accuracy = 0.0
             val amountOfTestSet = 10000
             for (imageId in 0..amountOfTestSet) {
-                val prediction = it.predict(train.getX(imageId))
-                val softPrediction = it.predictSoftly(train.getX(imageId))
+                val prediction = it.predict(train.getX(imageId).first)
+                val softPrediction = it.predictSoftly(train.getX(imageId).first)
                 assertEquals(10, softPrediction.size)
 
                 if (prediction == train.getY(imageId).toInt())
@@ -201,8 +201,8 @@ class TensorFlowInferenceModelTest {
             var accuracy = 0.0
             val amountOfTestSet = 10000
             for (imageId in 0..amountOfTestSet) {
-                val prediction = it.predict(train.getX(imageId))
-                val softPrediction = it.predictSoftly(train.getX(imageId))
+                val prediction = it.predict(train.getX(imageId).first)
+                val softPrediction = it.predictSoftly(train.getX(imageId).first)
                 assertEquals(10, softPrediction.size)
 
                 if (prediction == train.getY(imageId).toInt())
@@ -217,7 +217,7 @@ class TensorFlowInferenceModelTest {
             var accuracy = 0.0
             val amountOfTestSet = 10000
             for (imageId in 0..amountOfTestSet) {
-                val prediction = it.predict(train.getX(imageId))
+                val prediction = it.predict(train.getX(imageId).first)
 
                 if (prediction == train.getY(imageId).toInt())
                     accuracy += (1.0 / amountOfTestSet)
@@ -238,7 +238,7 @@ class TensorFlowInferenceModelTest {
             it.reshape(28, 28, 1)
 
             val exception = Assertions.assertThrows(IllegalStateException::class.java) {
-                it.predict(train.getX(0))
+                it.predict(train.getX(0).first)
             }
             assertEquals("Model weights are not initialized.", exception.message)
         }
@@ -252,7 +252,7 @@ class TensorFlowInferenceModelTest {
         inferenceModel.use {
             val exception =
                 Assertions.assertThrows(IllegalArgumentException::class.java) {
-                    it.predict(train.getX(0))
+                    it.predict(train.getX(0).first)
                 }
             assertEquals(
                 "Model input shape is not defined. Call reshape() to set input shape.",
@@ -261,7 +261,7 @@ class TensorFlowInferenceModelTest {
 
             val exception2 =
                 Assertions.assertThrows(IllegalArgumentException::class.java) {
-                    it.predictSoftly(train.getX(0))
+                    it.predictSoftly(train.getX(0).first)
                 }
             assertEquals(
                 "Model input shape is not defined. Call reshape() to set input shape.",

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/TensorFlowInferenceModelTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/TensorFlowInferenceModelTest.kt
@@ -144,8 +144,8 @@ class TensorFlowInferenceModelTest {
             var accuracy = 0.0
             val amountOfTestSet = 10000
             for (imageId in 0..amountOfTestSet) {
-                val prediction = it.predict(train.getX(imageId).first)
-                val softPrediction = it.predictSoftly(train.getX(imageId).first)
+                val prediction = it.predict(train.getX(imageId))
+                val softPrediction = it.predictSoftly(train.getX(imageId))
                 assertEquals(10, softPrediction.size)
 
                 if (prediction == train.getY(imageId).toInt())
@@ -201,8 +201,8 @@ class TensorFlowInferenceModelTest {
             var accuracy = 0.0
             val amountOfTestSet = 10000
             for (imageId in 0..amountOfTestSet) {
-                val prediction = it.predict(train.getX(imageId).first)
-                val softPrediction = it.predictSoftly(train.getX(imageId).first)
+                val prediction = it.predict(train.getX(imageId))
+                val softPrediction = it.predictSoftly(train.getX(imageId))
                 assertEquals(10, softPrediction.size)
 
                 if (prediction == train.getY(imageId).toInt())
@@ -217,7 +217,7 @@ class TensorFlowInferenceModelTest {
             var accuracy = 0.0
             val amountOfTestSet = 10000
             for (imageId in 0..amountOfTestSet) {
-                val prediction = it.predict(train.getX(imageId).first)
+                val prediction = it.predict(train.getX(imageId))
 
                 if (prediction == train.getY(imageId).toInt())
                     accuracy += (1.0 / amountOfTestSet)
@@ -238,7 +238,7 @@ class TensorFlowInferenceModelTest {
             it.reshape(28, 28, 1)
 
             val exception = Assertions.assertThrows(IllegalStateException::class.java) {
-                it.predict(train.getX(0).first)
+                it.predict(train.getX(0))
             }
             assertEquals("Model weights are not initialized.", exception.message)
         }
@@ -252,7 +252,7 @@ class TensorFlowInferenceModelTest {
         inferenceModel.use {
             val exception =
                 Assertions.assertThrows(IllegalArgumentException::class.java) {
-                    it.predict(train.getX(0).first)
+                    it.predict(train.getX(0))
                 }
             assertEquals(
                 "Model input shape is not defined. Call reshape() to set input shape.",
@@ -261,7 +261,7 @@ class TensorFlowInferenceModelTest {
 
             val exception2 =
                 Assertions.assertThrows(IllegalArgumentException::class.java) {
-                    it.predictSoftly(train.getX(0).first)
+                    it.predictSoftly(train.getX(0))
                 }
             assertEquals(
                 "Model input shape is not defined. Call reshape() to set input shape.",

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/TensorFlowInferenceModelTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/TensorFlowInferenceModelTest.kt
@@ -140,7 +140,6 @@ class TensorFlowInferenceModelTest {
 
         val inferenceModel = TensorFlowInferenceModel.load(tempDir.toFile(), loadOptimizerState = false)
         inferenceModel.use {
-            it.reshape(28, 28, 1)
             var accuracy = 0.0
             val amountOfTestSet = 10000
             for (imageId in 0..amountOfTestSet) {
@@ -197,7 +196,6 @@ class TensorFlowInferenceModelTest {
         val secondAccuracy: Double
 
         inferenceModel.use {
-            it.reshape(28, 28, 1)
             var accuracy = 0.0
             val amountOfTestSet = 10000
             for (imageId in 0..amountOfTestSet) {
@@ -235,38 +233,10 @@ class TensorFlowInferenceModelTest {
 
         val inferenceModel = TensorFlowInferenceModel()
         inferenceModel.use {
-            it.reshape(28, 28, 1)
-
             val exception = Assertions.assertThrows(IllegalStateException::class.java) {
                 it.predict(train.getX(0))
             }
             assertEquals("Model weights are not initialized.", exception.message)
-        }
-    }
-
-    @Test
-    fun missedReshapeFunction() {
-        val (train, _) = mnist()
-
-        val inferenceModel = TensorFlowInferenceModel()
-        inferenceModel.use {
-            val exception =
-                Assertions.assertThrows(IllegalArgumentException::class.java) {
-                    it.predict(train.getX(0))
-                }
-            assertEquals(
-                "Model input shape is not defined. Call reshape() to set input shape.",
-                exception.message
-            )
-
-            val exception2 =
-                Assertions.assertThrows(IllegalArgumentException::class.java) {
-                    it.predictSoftly(train.getX(0))
-                }
-            assertEquals(
-                "Model input shape is not defined. Call reshape() to set input shape.",
-                exception2.message
-            )
         }
     }
 

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/ml/RegressionTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/ml/RegressionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -98,7 +98,7 @@ internal class RegressionTest {
 
             var simpleMae = 0.0f
             repeat(100) { id ->
-                val xReal = test.getX(id).first
+                val xReal = test.getX(id)
                 val yReal = test.getY(id)
 
                 val yPred = it.predictSoftly(xReal)

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/ml/RegressionTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/ml/RegressionTest.kt
@@ -98,7 +98,7 @@ internal class RegressionTest {
 
             var simpleMae = 0.0f
             repeat(100) { id ->
-                val xReal = test.getX(id)
+                val xReal = test.getX(id).first
                 val yReal = test.getY(id)
 
                 val yPred = it.predictSoftly(xReal)

--- a/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/ml/RegressionTest.kt
+++ b/tensorflow/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/ml/RegressionTest.kt
@@ -68,10 +68,7 @@ internal class RegressionTest {
             return labels
         }
 
-        val dataset = OnHeapDataset.create(
-            ::extractX,
-            ::extractY
-        )
+        val dataset = OnHeapDataset.create(extractX(), extractY())
 
         val (train, test) = dataset.split(0.9)
 

--- a/visualization/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/visualization/letsplot/PlotConv2D.kt
+++ b/visualization/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/visualization/letsplot/PlotConv2D.kt
@@ -1,11 +1,12 @@
 /*
- * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2021-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
 package org.jetbrains.kotlinx.dl.visualization.letsplot
 
 import jetbrains.letsPlot.Figure
+import org.jetbrains.kotlinx.dl.api.core.FloatData
 import org.jetbrains.kotlinx.dl.api.core.TrainableModel
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.weights
@@ -57,7 +58,7 @@ fun filtersPlot(
  */
 fun modelActivationOnLayersPlot(
     model: TrainableModel,
-    x: FloatArray,
+    x: FloatData,
     plotFeature: PlotFeature = PlotFeature.GRAY,
     imageSize: Int = 64,
     columns: Int = 8,

--- a/visualization/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/visualization/letsplot/PlotGeneric.kt
+++ b/visualization/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/visualization/letsplot/PlotGeneric.kt
@@ -86,7 +86,7 @@ fun flattenImagePlot(
     plotFeature: PlotFeature = PlotFeature.GRAY
 ): Plot {
     val imageSize = 28
-    val imageData = dataset.getX(sampleNumber)
+    val imageData = dataset.getX(sampleNumber).first
     val imageLabel = dataset.getY(sampleNumber).toInt().run(labelEncoding)
     val predictedLabel = predict(imageData)?.run(labelEncoding)
     val title = if (predictedLabel == null) {

--- a/visualization/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/visualization/letsplot/PlotGeneric.kt
+++ b/visualization/src/jvmMain/kotlin/org/jetbrains/kotlinx/dl/visualization/letsplot/PlotGeneric.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2021-2023 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -11,6 +11,8 @@ import jetbrains.letsPlot.gggrid
 import jetbrains.letsPlot.intern.Plot
 import jetbrains.letsPlot.label.ggtitle
 import jetbrains.letsPlot.letsPlot
+import org.jetbrains.kotlinx.dl.api.core.FloatData
+import org.jetbrains.kotlinx.dl.api.core.floats
 import org.jetbrains.kotlinx.dl.dataset.Dataset
 import org.jetbrains.kotlinx.dl.dataset.audio.wav.WavFile
 import kotlin.math.max
@@ -81,12 +83,12 @@ fun xyPlot(imageSize: Int, plotFeature: PlotFeature, f: (Int, Int) -> Float): Pl
 fun flattenImagePlot(
     sampleNumber: Int,
     dataset: Dataset,
-    predict: (FloatArray) -> Int? = { null },
+    predict: (FloatData) -> Int? = { null },
     labelEncoding: (Int) -> Any? = { it },
     plotFeature: PlotFeature = PlotFeature.GRAY
 ): Plot {
     val imageSize = 28
-    val imageData = dataset.getX(sampleNumber).first
+    val imageData = dataset.getX(sampleNumber)
     val imageLabel = dataset.getY(sampleNumber).toInt().run(labelEncoding)
     val predictedLabel = predict(imageData)?.run(labelEncoding)
     val title = if (predictedLabel == null) {
@@ -95,7 +97,7 @@ fun flattenImagePlot(
         "Real label: $imageLabel | Predicted label: $predictedLabel"
     }
 
-    return xyPlot(imageSize, plotFeature) { x, y -> imageData[y * imageSize + x] } + ggtitle(title)
+    return xyPlot(imageSize, plotFeature) { x, y -> imageData.floats[y * imageSize + x] } + ggtitle(title)
 }
 
 /**


### PR DESCRIPTION
This PR is a continuation of #494. It adds shape information for all the data used for prediction and training. Since `shape` is always known, we can create tensors for the data more easily.

Some models do not have the input shape defined and data with arbitrary shape can be used (ex `EfficientDetObjectDetectionModel`). In this PR such models still use `resize` operation in preprocessing, so they still have some input shape set manually for this. Maybe this is not needed (?)